### PR TITLE
appendNavTrail() to addNavTrail() migration

### DIFF
--- a/hdrl/src/org/labkey/hdrl/HDRLController.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLController.java
@@ -122,9 +122,9 @@ public class HDRLController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("HDRL Test Request Overview");
+            root.addChild("HDRL Test Request Overview");
         }
     }
 
@@ -157,9 +157,9 @@ public class HDRLController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Test Request");
+            root.addChild("Test Request");
         }
     }
 
@@ -190,9 +190,9 @@ public class HDRLController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild(_navLabel);
+            root.addChild(_navLabel);
         }
     }
 
@@ -405,9 +405,8 @@ public class HDRLController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return null;
         }
     }
 
@@ -516,9 +515,9 @@ public class HDRLController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild(_navLabel);
+            root.addChild(_navLabel);
         }
     }
 

--- a/icemr/src/org/labkey/icemr/IcemrController.java
+++ b/icemr/src/org/labkey/icemr/IcemrController.java
@@ -79,6 +79,7 @@ public class IcemrController extends SpringActionController
             return super.getView(form, errors);
         }
 
+        @Override
         public void addNavTrail(NavTree root)
         {
             ActionURL runDataURL = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(getContainer(), _protocol, _runRowId);
@@ -126,6 +127,7 @@ public class IcemrController extends SpringActionController
             QuerySettings settings = schema.getSettings(_context, AssayProtocolSchema.DATA_TABLE_NAME, AssayProtocolSchema.DATA_TABLE_NAME);
             QueryView dataView = new DrugSensitivityProtocolSchema.ResultsQueryView(_protocol, _context, settings)
             {
+                @Override
                 public DataView createDataView()
                 {
                     DataView view = super.createDataView();

--- a/icemr/src/org/labkey/icemr/IcemrController.java
+++ b/icemr/src/org/labkey/icemr/IcemrController.java
@@ -79,12 +79,11 @@ public class IcemrController extends SpringActionController
             return super.getView(form, errors);
         }
 
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
             ActionURL runDataURL = PageFlowUtil.urlProvider(AssayUrls.class).getAssayResultsURL(getContainer(), _protocol, _runRowId);
             root.addChild(_protocol.getName() + " Data", runDataURL);
             root.addChild("Run " + _runRowId + " Details");
-            return root;
         }
     }
 

--- a/icemr/src/org/labkey/icemr/IcemrModule.java
+++ b/icemr/src/org/labkey/icemr/IcemrModule.java
@@ -77,6 +77,7 @@ public class IcemrModule extends DefaultModule
         {
             DefaultSchema.registerProvider(schemaName, new DefaultSchema.SchemaProvider(this)
             {
+                @Override
                 public QuerySchema createSchema(final DefaultSchema schema, Module module)
                 {
                     return QueryService.get().createSimpleUserSchema(schemaName, null, schema.getUser(), schema.getContainer(), IcemrSchema.getInstance().getSchema());

--- a/icemr/src/org/labkey/icemr/assay/DrugSensitivity/DrugSensitivityDataHandler.java
+++ b/icemr/src/org/labkey/icemr/assay/DrugSensitivity/DrugSensitivityDataHandler.java
@@ -81,6 +81,7 @@ public class DrugSensitivityDataHandler extends DilutionDataHandler
         return "txt";
     }
 
+    @Override
     protected double[][] getCellValues(File dataFile, PlateTemplate template) throws ExperimentException
     {
         double[][] cellValues = new double[template.getRows()][template.getColumns()];

--- a/icemr/src/org/labkey/icemr/assay/Tracking/AdaptationSaveHandler.java
+++ b/icemr/src/org/labkey/icemr/assay/Tracking/AdaptationSaveHandler.java
@@ -207,18 +207,25 @@ public class AdaptationSaveHandler implements AssaySaveHandler
         return samples;
     }
 
+    @Override
     public void setProvider(AssayProvider provider)
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public AssayProvider getProvider()
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public ExpExperiment handleBatch(ViewContext context, JSONObject batchJson, ExpProtocol protocol)
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public ExpRun handleRun(ViewContext context, JSONObject runJson, ExpProtocol protocol, ExpExperiment batch) throws JSONException
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public ExpData handleData(ViewContext context, JSONObject dataJson)
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public void handleProperties(ViewContext context, ExpObject object, List<? extends DomainProperty> dps, JSONObject propertiesJson) throws JSONException
     { throw new IllegalStateException(INVALID_ACTION); }
+    @Override
     public void beforeSave(ViewContext context, JSONObject rootJson, ExpProtocol protocol)
     { throw new IllegalStateException(INVALID_ACTION); }
     public void handleProtocolApplications(ViewContext context, ExpProtocol protocol, ExpExperiment batch, ExpRun run, JSONArray inputDataArray,
@@ -226,6 +233,7 @@ public class AdaptationSaveHandler implements AssaySaveHandler
         JSONArray outputMaterialArray)
     { throw new IllegalStateException(INVALID_ACTION); }
 
+    @Override
     public ExpRun handleRunWithoutBatch(ViewContext context, JSONObject runJson, ExpProtocol protocol)
     {
         throw new UnsupportedOperationException(INVALID_ACTION);

--- a/icemr/test/src/org/labkey/test/tests/icemr/ICEMRModuleTest.java
+++ b/icemr/test/src/org/labkey/test/tests/icemr/ICEMRModuleTest.java
@@ -223,6 +223,7 @@ public class ICEMRModuleTest extends BaseWebDriverTest
         goToProjectHome();
     }
 
+    @Override
     protected void doCleanup(boolean afterTest) throws TestTimeoutException
     {
         _userHelper.deleteUsers(false, ICEMR_AUTHOR_USER, ICEMR_EDITOR_USER);

--- a/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsController.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsController.java
@@ -131,9 +131,9 @@ public class MS2ExtensionsController extends SpringActionController
         }
 
         @Override
-        public NavTree appendNavTrail(NavTree root)
+        public void addNavTrail(NavTree root)
         {
-            return root.addChild("Update Peptide Counts");
+            root.addChild("Update Peptide Counts");
         }
     }
 

--- a/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
@@ -129,6 +129,7 @@ public class MS2ExtensionsModule extends DefaultModule
 
         DefaultSchema.registerProvider(SCHEMA_NAME, new DefaultSchema.SchemaProvider(this)
         {
+            @Override
             public QuerySchema createSchema(DefaultSchema schema, Module module)
             {
                 return new SimpleUserSchema(SCHEMA_NAME, null, schema.getUser(), schema.getContainer(), MS2ExtensionsModule.getSchema());

--- a/viscstudies/src/org/labkey/viscstudies/ViscStudyFolderType.java
+++ b/viscstudies/src/org/labkey/viscstudies/ViscStudyFolderType.java
@@ -55,6 +55,7 @@ public class ViscStudyFolderType extends MultiPortalFolderType
                 getModule("Study"));
     }
 
+    @Override
     protected String getFolderTitle(ViewContext ctx)
     {
         Study study = StudyService.get().getStudy(ctx.getContainer());


### PR DESCRIPTION
#### Rationale
Adjust actions to implement `void addNavTrail()` instead of `NavTree appendNavTrail()`. Also, bulk annotate with @Override. See platform PR for more details.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1199