### PR TITLE
Test update due to update to GetQueryDetailsAction

### DIFF
--- a/viscstudies/src/org/labkey/viscstudies/ViscStudySchema.java
+++ b/viscstudies/src/org/labkey/viscstudies/ViscStudySchema.java
@@ -33,7 +33,7 @@ import java.util.Set;
 public class ViscStudySchema extends UserSchema
 {
     public static final String NAME = "viscstudies";
-    public static final String STUDY_TABLE_NAME = "studies";
+    public static final String STUDY_TABLE_NAME = "Study";
 
     public ViscStudySchema(User user, Container container)
     {

--- a/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
+++ b/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
@@ -571,7 +571,7 @@ public class CAVDStudyTest extends StudyBaseTest
     {
         navigateToFolder(PROJECT_NAME, folderName);
         goToSchemaBrowser();
-        selectQuery("viscstudies", "studies", "Study");
+        selectQuery("viscstudies", "Study");
         waitForText("view data");
         clickAndWait(Locator.linkContainingText("view data"));
     }

--- a/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
+++ b/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
@@ -571,7 +571,7 @@ public class CAVDStudyTest extends StudyBaseTest
     {
         navigateToFolder(PROJECT_NAME, folderName);
         goToSchemaBrowser();
-        selectQuery("viscstudies", "studies");
+        selectQuery("viscstudies", "studies", "Study");
         waitForText("view data");
         clickAndWait(Locator.linkContainingText("view data"));
     }


### PR DESCRIPTION
#### Rationale
GetQueryDetailsAction was updated to return the public name instead of the name that was passed in.  That public name is displayed in the details section of the schema browser.  This test update accounts for that change.

#### Related Pull Requests
https://github.com/LabKey/platform/pull/1379

#### Changes
- Various test updates to look for public name to verify details have loaded
