### PR TITLE
Fb jsp final

### DIFF
--- a/hdrl/src/org/labkey/hdrl/view/printPackingList.jsp
+++ b/hdrl/src/org/labkey/hdrl/view/printPackingList.jsp
@@ -65,7 +65,7 @@
     <tr><td col width="50%"><br><b>Shipment Information:</b></td></tr>
     <tr>
         <td col width="50%">Courier: <%=h(packingListBean.getShippingCarrier())%></td>
-        <td  col width="50%" align="left">Total Samples: <%=h(packingListBean.getTotalSamples())%> </td>
+        <td col width="50%" align="left">Total Samples: <%=packingListBean.getTotalSamples()%> </td>
     </tr>
     <tr>
         <td col width="50%">Tracking Number: <%=h(packingListBean.getShippingNumber())%></td>

--- a/hdrl/src/org/labkey/hdrl/view/requestDetails.jsp
+++ b/hdrl/src/org/labkey/hdrl/view/requestDetails.jsp
@@ -78,7 +78,7 @@
             width: 150,
             handler: function(){
                 window.open(LABKEY.ActionURL.buildURL('hdrl', 'printPackingList', null, {
-                    requestId : <%=h(bean.getRequestId())%>
+                    requestId: <%=bean.getRequestId()%>
                 }));
             }
         });

--- a/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
+++ b/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
@@ -16,11 +16,10 @@
  */
 %>
 <%@ page import="org.labkey.api.util.GUID" %>
-<%@ page import="org.labkey.api.util.PageFlowUtil" %>
-<%@ page import="org.labkey.api.view.ActionURL" %>
 <%@ page import="org.labkey.api.view.ViewContext" %>
 <%@ page import="org.labkey.ms2extensions.FilterView" %>
 <%@ page import="org.labkey.ms2extensions.MS2ExtensionsController" %>
+<%@ page import="org.labkey.ms2extensions.MS2ExtensionsController.SetPreferencesAction" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
     ViewContext context = getViewContext();
@@ -124,7 +123,7 @@
         var matchCriteria = document.getElementById(<%=q(matchCriteriaId)%>).value;
 
         // Fire off an AJAX request so that we repopulate with the last used values
-        var preferencesURL = <%=q(new ActionURL(MS2ExtensionsController.SetPreferencesAction.class, getContainer()))%>;
+        var preferencesURL = <%=q(urlFor(SetPreferencesAction.class))%>;
         Ext4.Ajax.request({ url: preferencesURL, method: 'POST', jsonData:
         {
             peptideFilter : viewName,

--- a/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
+++ b/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
@@ -124,7 +124,7 @@
         var matchCriteria = document.getElementById(<%=q(matchCriteriaId)%>).value;
 
         // Fire off an AJAX request so that we repopulate with the last used values
-        var preferencesURL = <%=q(new ActionURL(MS2ExtensionsController.SetPreferencesAction.class, getContainer()).toString())%>;
+        var preferencesURL = <%=q(new ActionURL(MS2ExtensionsController.SetPreferencesAction.class, getContainer()))%>;
         Ext4.Ajax.request({ url: preferencesURL, method: 'POST', jsonData:
         {
             peptideFilter : viewName,


### PR DESCRIPTION
#### Rationale
String-based URL manipulation is risky; use `urlFor()`. No need to encode ints.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/1549