### PR TITLE
Add missing module dependencies and move dependencies declarations out of module.properties files

### DIFF
--- a/hvtnFlow/build.gradle
+++ b/hvtnFlow/build.gradle
@@ -1,0 +1,4 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: 'published', depExtension: 'module')
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "flow"), depProjectConfig: 'published', depExtension: 'module')

--- a/hvtnFlow/module.properties
+++ b/hvtnFlow/module.properties
@@ -1,3 +1,3 @@
 Name: hvtnFlow
 RequiredServerVersion: 10.20
-ModuleDependencies: Experiment, Flow
+

--- a/ms2extensions/build.gradle
+++ b/ms2extensions/build.gradle
@@ -3,4 +3,5 @@ import org.labkey.gradle.util.BuildUtils;
 dependencies
 {
    BuildUtils.addLabKeyDependency(project: project, config: "implementation", depProjectPath:  BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: "apiJarFile")
+   BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getCommonAssayModuleProjectPath(project.gradle, "ms2"), depProjectConfig: 'published', depExtension: 'module')
 }

--- a/ms2extensions/module.properties
+++ b/ms2extensions/module.properties
@@ -1,2 +1,1 @@
-ModuleDependencies=ms2
 ModuleClass: org.labkey.ms2extensions.MS2ExtensionsModule

--- a/peptideInventory/build.gradle
+++ b/peptideInventory/build.gradle
@@ -1,0 +1,3 @@
+import org.labkey.gradle.util.BuildUtils
+
+BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "experiment"), depProjectConfig: 'published', depExtension: 'module')

--- a/peptideInventory/module.properties
+++ b/peptideInventory/module.properties
@@ -1,5 +1,4 @@
 Name: PeptideInventory
 SchemaVersion: 20.000
-ModuleDependencies: Experiment
 SupportedDatabases: pgsql
 


### PR DESCRIPTION
#### Rationale
We have deprecated the declaration of module dependencies in the `module.properties` file in favor of declaration in the `build.gradle` file.

#### Changes
* Move module dependency declarations from `module.properties` files to `build.gradle` files
