### PR TITLE
Fix button locator to not find hidden link to 'EditableModule'

### DIFF
--- a/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
+++ b/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
@@ -196,7 +196,7 @@ public class CAVDStudyTest extends StudyBaseTest
         // 1. inactivate the Canarypox type
         goToGWTStudyDesignerPanel(FOLDER_NAME, "VACCINE");
         waitForText("Adjuvants");
-        clickAndWait(Locator.linkContainingText("Edit"));
+        clickAndWait(Locator.id("button_Edit"));
         waitForText("Configure Dropdown Options");
         click(Locator.linkContainingText("Configure Dropdown Options"));
         clickAndWait(Locator.linkWithText("folder").index(0));  // configure the first type 'Immunogen Types'


### PR DESCRIPTION
#### Rationale
The old Locator was not specific enough, causing it to find a link in the collapsed admin menu instead of the actual 'Edit' button.
```
org.openqa.selenium.ElementNotInteractableException: Element <a href="/labkey/CAVDStudyTest%20Project/CAVDStudyTest%20Folder/editablemodule-begin.view?"> could not be scrolled into view
```

#### Changes
* Use a more specific Locator for the edit button.

<details>
<summary>Screenshot</summary>

![Screen Shot 2020-10-20 at 10 22 48 AM](https://user-images.githubusercontent.com/5263798/96634324-30220c00-12cf-11eb-9433-70df1c47e52e.png)
</details>