### PR TITLE
customLogin module: provides clone of standard login page with "username" replacing "email" references

### DIFF
--- a/customLogin/build.gradle
+++ b/customLogin/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'org.labkey.build.fileModule'
+}

--- a/customLogin/module.properties
+++ b/customLogin/module.properties
@@ -1,0 +1,6 @@
+Name: customLogin
+Description: Provides a custom login page that's identical to the standard login page except that it \
+    uses the term "Username" instead of "Email address". Configure this by setting Admin Console -> \
+    Look and Feel Settings -> Alternative login page to "customLogin-login"
+License: Apache 2.0
+LicenseURL: https://www.apache.org/licenses/LICENSE-2.0

--- a/customLogin/resources/views/login.html
+++ b/customLogin/resources/views/login.html
@@ -1,0 +1,47 @@
+<form class="auth-form" name="login" action="javascript:void(0)" method="post">
+    <div class="auth-header">Sign In</div>
+    <div class="labkey-error" id="errors"></div>
+    <div class="auth-form-body">
+        <label for="email">Username</label>
+        <input id="email" name="email" type="text" class="input-block" tabindex="1" autocomplete="off">
+        <label for="password">Password</label>
+        <div class="forgot-password-link">
+            <a href="login-resetPassword.view?">Forgot password</a>
+        </div>
+        <input id="password" name="password" type="password" class="input-block" tabindex="2" autocomplete="off">
+        <input tabindex="3" type="checkbox" name="remember" id="remember"  checked> Remember my username
+        <div class="termsOfUseSection" hidden>
+            <div class="auth-header auth-item">Terms of Use</div>
+            <div class="toucontent auth-item termsOfUseContent"></div>
+            <div class="auth-item">
+                <input type="checkbox" tabindex="4" name="approvedTermsOfUse" id="approvedTermsOfUse" class="auth-item" unchecked>
+                <label for="approvedTermsOfUse">I agree to these terms</label>
+            </div>
+        </div>
+        <input type="hidden" name="termsOfUseType" id="termsOfUseType">
+        <div class="auth-item auth-credentials-submit">
+            <input type="submit" tabindex="-1" class="loginSubmitButton"/>
+            <a tabindex="5" class="labkey-button primary signin-btn"><span>Sign In</span></a>
+            <span class="registrationSection" hidden>
+                <a class="labkey-button" id="registerButton" href="login-register.view?">Register</a>
+            </span>
+        </div>
+        <div class="signing-in-msg" hidden>
+            <span class="fa fa-spinner fa-pulse"></span> Signing you in. This may take a moment.
+        </div>
+
+        <input type="hidden" name="returnUrl">
+        <input type="hidden" id="urlhash" name="urlhash">
+        <input type="hidden" name='X-LABKEY-CSRF'>
+    </div>
+</form>
+<div class="otherLoginMechanismsSection" hidden>
+    <div class="auth-header">Or Sign In using</div>
+    <div class="otherLoginMechanismsContent"></div>
+</div>
+
+<script type="application/javascript">
+    if (LABKEY.ActionURL.getParameter('returnUrl')) {
+        document.getElementById('registerButton').href += 'returnUrl=' + encodeURIComponent(LABKEY.ActionURL.getParameter('returnUrl'));
+    }
+</script>

--- a/customLogin/resources/views/login.view.xml
+++ b/customLogin/resources/views/login.view.xml
@@ -1,0 +1,6 @@
+<view xmlns="http://labkey.org/data/xml/view">
+    <dependencies>
+        <dependency path="login.css"/>
+        <dependency path="login.js"/>
+    </dependencies>
+</view>


### PR DESCRIPTION
#### Rationale
Client wanted a login page that references "username" instead of "email"

#### Related Pull Requests
* https://github.com/LabKey/distributions/pull/228
