### PR TITLE
Ticket 44458: Filters are being ignored in the peptides table grid view

### DIFF
--- a/ms2extensions/src/org/labkey/ms2extensions/RunGridWebPart.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/RunGridWebPart.java
@@ -70,6 +70,12 @@ public class RunGridWebPart extends VBox
 
     public static void populateButtonBar(ButtonBar bar, String dataRegionName)
     {
+        ActionButton viewPeptidesButton = new ActionButton("View Peptides");
+        viewPeptidesButton.setScript("viewPeptides(" + PageFlowUtil.jsString(dataRegionName) + "); return false;", false);
+        viewPeptidesButton.setActionType(ActionButton.Action.SCRIPT);
+        viewPeptidesButton.setRequiresSelection(true);
+        bar.add(viewPeptidesButton);
+
         ActionButton comparePeptidesButton = new ActionButton("Compare Peptides");
         comparePeptidesButton.setScript("comparePeptides(" + PageFlowUtil.jsString(dataRegionName) + "); return false;", false);
         comparePeptidesButton.setActionType(ActionButton.Action.SCRIPT);


### PR DESCRIPTION
#### Rationale
The customer wants to be able to select a subset of runs (including runs spread across multiple folders) and view the peptides for them

#### Changes
* Add a new View Peptides button to the custom MS2 runs list
* Use the selection to create a URL-based filter of MS2 run IDs