### PR TITLE
Ticket 44458: View peptides based on run group membership

### DIFF
--- a/ms2extensions/resources/queries/exp/RunGroups.query.xml
+++ b/ms2extensions/resources/queries/exp/RunGroups.query.xml
@@ -1,0 +1,34 @@
+<tables xmlns="http://labkey.org/data/xml">
+    <table tableName="RunGroups" tableDbType="NOT_IN_DB">
+        <buttonBarOptions includeStandardButtons="true">
+            <item text="View Peptides" requiresSelection="true">
+                <onClick>
+                    dataRegion.getSelected({ success:
+                        function(data) {
+                            // Translate from run group RowId to Name
+                            LABKEY.Query.selectRows({
+                                schemaName: 'exp',
+                                queryName: 'RunGroups',
+                                containerFilter: dataRegion.containerFilter,
+                                columns: 'Name',
+                                filterArray: [LABKEY.Filter.create('RowId', data.selected.join(';'), LABKEY.Filter.Types.EQUALS_ONE_OF)],
+                                success: function(data) {
+                                    // Send the user to a page filtered to show peptides in runs belonging to those groups
+                                    let params = {
+                                        schemaName: 'ms2',
+                                        queryName: 'SequestPeptides',
+                                        'query.containerFilterName': 'AllFolders'
+                                    };
+                                    for (var i = 0; i &lt; data.rows.length; i++) {
+                                        params['query.' + LABKEY.FieldKey.fromParts('Fraction', 'Run', 'ExperimentRunLSID', 'RunGroupToggle', data.rows[i].Name).toString() + '~eq'] = 1;
+                                    }
+                                    window.location = LABKEY.ActionURL.buildURL('query', 'executeQuery', null, params);
+                                }
+                            });
+                        }
+                    })
+                </onClick>
+            </item>
+        </buttonBarOptions>
+    </table>
+</tables>


### PR DESCRIPTION
#### Rationale
We added a way to go from the run listing to see the associated peptides, but it doesn't scale to thousands of selected runs due to GET URL limits. Since the use case is based around selecting runs from a particular run group, it should be faster and easier to go from the run group listing instead.

#### Changes
* Add a View Peptides button to the Run Groups grid that operates on the current selection. If multiple are selected, a peptide's run must be a member of all of the groups to satisfy the filter.