### PR TITLE
Remove unnecessary ids to avoid collisions

### DIFF
--- a/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
+++ b/ms2extensions/src/org/labkey/ms2extensions/runGridFilters.jsp
@@ -56,7 +56,7 @@
                     String peptideViewSelectId = peptideView.renderViewList(request, out, MS2ExtensionsController.getPeptideFilterPreference(context));
                 %>
 
-                <%=link("Create or Edit View").onClick("showViewDesigner('PeptidesFilter', '" + peptideCustomizeViewId + "', " + q(peptideViewSelectId) + ", viewSavedCallback); return false;").id("editPeptidesViewLink")%>
+                <%=link("Create or Edit View").onClick("showViewDesigner('PeptidesFilter', '" + peptideCustomizeViewId + "', " + q(peptideViewSelectId) + ", viewSavedCallback); return false;")%>
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
#### Rationale
The `platform` change that checks for overlapping event handlers flagged these ids. Nothing else references them by ID, so there's not much point in explicitly defining the ids.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/3260

#### Changes
* Remove unnecessary link ids to avoid collisions
