### PR TITLE
Update CAVDStudyTest - Webpart Header

### DIFF
--- a/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
+++ b/viscstudies/test/src/org/labkey/test/tests/viscstudies/CAVDStudyTest.java
@@ -190,7 +190,8 @@ public class CAVDStudyTest extends StudyBaseTest
         addGroup("Vaccine2", true, "3", 3);
         addTimepoint("CAVDImmTimepoint", "0", TimeUnit.Days);
         finishRevision();
-        waitForText("Immunization Schedule", 4, defaultWaitForPage); // WebPart title and schedule table header
+        waitForText("Immunization Schedule", 3, defaultWaitForPage); // WebPart title and schedule table header
+        assertElementPresent(Locator.tagWithId("a", "ImmunizationSchedule")); // Verify anchor tag on WebPart title
         assertTextPresent(_expectedImmunizationText);
         assertElementNotPresent(Locator.tagWithText("div", "30")); // From deleted rows
 


### PR DESCRIPTION
#### Rationale
The related PR switched webpart title tag to use a valid Id (no spaces), instead of name with spaces. This PR updates the CAVDStudyTest for this change. 

#### Related Pull Requests
https://github.com/LabKey/platform/pull/4715

#### Changes
* Update CAVDStudyTest
