### PR TITLE
Remove deprecated ContainerFilter.getSQLFragment

### DIFF
--- a/hdrl/src/org/labkey/hdrl/query/RequestResultTable.java
+++ b/hdrl/src/org/labkey/hdrl/query/RequestResultTable.java
@@ -39,7 +39,7 @@ public class RequestResultTable extends ResultTable
         SQLFragment sql = new SQLFragment(getIdField() + " IN (SELECT r.RequestId FROM ");
         sql.append(HDRLSchema.getInstance().getTableInfoInboundRequest(), "r");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("r.Container")));
         sql.append(")");
         addCondition(sql, containerFieldKey);
     }

--- a/hdrl/src/org/labkey/hdrl/query/SpecimenResultTable.java
+++ b/hdrl/src/org/labkey/hdrl/query/SpecimenResultTable.java
@@ -40,7 +40,7 @@ public class SpecimenResultTable extends ResultTable
         SQLFragment sql = new SQLFragment(getIdField() + " IN (SELECT s.RowId FROM ");
         sql.append(HDRLSchema.getInstance().getTableInfoInboundSpecimen(), "s");
         sql.append(" WHERE ");
-        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("s.Container"), getContainer()));
+        sql.append(filter.getSQLFragment(getSchema(), new SQLFragment("s.Container")));
         sql.append(")");
         addCondition(sql, containerFieldKey);
     }


### PR DESCRIPTION
#### Rationale
See https://github.com/LabKey/platform/pull/5073 for rationale.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/5073

#### Changes
* Remove `ContainerFilter.getSQLFragment(DbSchema, SQLFragment, Container)` and replace usages with calls to `ContainerFilter.getSQLFragment(DbSchema, SQLFragment)`.
