### PR TITLE
Mark modules that support both databases

### DIFF
--- a/ms2extensions/module.properties
+++ b/ms2extensions/module.properties
@@ -1,1 +1,2 @@
 ModuleClass: org.labkey.ms2extensions.MS2ExtensionsModule
+SupportedDatabases: mssql, pgsql


### PR DESCRIPTION
#### Rationale
Need to explicitly declare support for SQL Server since we're about to change the default to PostgreSQL-only