### PR TITLE
Update AnalysisPlanBase.sql

### DIFF
--- a/hvtnFlow/resources/queries/flow/AnalysisPlanBase.sql
+++ b/hvtnFlow/resources/queries/flow/AnalysisPlanBase.sql
@@ -106,7 +106,7 @@ NULL AS VISITDAY,
 ' ' AS COLORS,
 'S' AS STAIN,
 FCSAnalyses.RowId AS AnalysisResults,
-FCSAnalyses.FCSFile.Name As FCSFileName,
+FCSAnalyses.FCSFile.Keyword.$FIL AS FCSFileName,
 -- make sample available by selecting fcsfile
 FCSAnalyses.FCSFile as _fcsfile,
 FCSAnalyses.RowId as _well,


### PR DESCRIPTION
updated the expression for the FCSFilename field selected in AnalysisPlanBase.sql

#### Rationale
steve requested the FCSFilename be the $FIL keyword value across all queries. This is best done by editing the field in AnalysisPlanBase.sql

#### Related Pull Requests
* <!-- list of links to related pull requests (replace this comment) -->

#### Changes
* use FCSAnalyses.FCSFile.Keyword.$FIL for FCSFilename instead of FCSAnalyses.FCSFile.Name As FCSFileName
