### PR TITLE
Migrate <permissionClasses> -> <requiresPermissions>

### DIFF
--- a/atlastools/resources/views/dataUploadDashboard.view.xml
+++ b/atlastools/resources/views/dataUploadDashboard.view.xml
@@ -1,5 +1,5 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.ReadPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
 </view>

--- a/atlastools/resources/views/recoverNAbFiles.view.xml
+++ b/atlastools/resources/views/recoverNAbFiles.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
         <dependency path="internal/jQuery" />

--- a/atlastools/resources/views/recoverNAbFolders.view.xml
+++ b/atlastools/resources/views/recoverNAbFolders.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.AdminPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="Ext4" />
         <dependency path="internal/jQuery" />

--- a/peptideInventory/resources/views/manage.view.xml
+++ b/peptideInventory/resources/views/manage.view.xml
@@ -1,7 +1,7 @@
 <view xmlns="http://labkey.org/data/xml/view" title="Manage Peptide Inventory">
-    <permissionClasses>
+    <requiresPermissions>
         <permissionClass name="org.labkey.api.security.permissions.InsertPermission"/>
-    </permissionClasses>
+    </requiresPermissions>
     <dependencies>
         <dependency path="clientapi/ext3" />
         <dependency path="clientapi/ext4" />


### PR DESCRIPTION
#### Rationale
We recommend `<requiresPermissions>` since it matches the other elements and action annotations; use what we document so we propagate the recommended element. `<permissionsClasses>` remains a valid synonym.