### PR TITLE
Handle bad peptide_group_id values more gracefully

### DIFF
--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
@@ -33,6 +33,7 @@ import org.labkey.api.view.HttpView;
 import org.labkey.api.view.InsertView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
+import org.labkey.api.view.NotFoundException;
 import org.labkey.api.view.UpdateView;
 import org.labkey.api.view.VBox;
 import org.labkey.api.view.ViewContext;
@@ -442,7 +443,18 @@ public class PepDBController extends PepDBBaseController
         public ModelAndView getView(PeptideAndGroupForm form, BindException errors) throws Exception
         {
             _log.debug("PeptideAndGroupForm: " + form.toString());
-            PeptideGroup pg = PepDBManager.getPeptideGroupByID(Integer.parseInt(form.getPeptide_group_id()));
+            PeptideGroup pg = null;
+            try
+            {
+                int peptideGroupId = Integer.parseInt(form.getPeptide_group_id());
+                pg = PepDBManager.getPeptideGroupByID(peptideGroupId);
+            }
+            catch (NumberFormatException ignored) {}
+            if (pg == null || !getContainer().getId().equalsIgnoreCase(pg.getContainerId()))
+            {
+                throw new NotFoundException();
+            }
+
             DataRegion rgn1 = new DataRegion();
             TableInfo tableInfo1 = PepDBSchema.getInstance().getTableInfoPeptideGroups();
             rgn1.setColumns(tableInfo1.getColumns("peptide_group_id,peptide_group_name,pathogen_id,seq_ref,clade_id,pep_align_ref_id,group_type_id,createdby,created,modifiedby,modified"));


### PR DESCRIPTION
#### Rationale
The crawler found a place where we return a 500 error for bad IDs on the URL

```
ERROR ExceptionUtil            2025-03-02T19:49:29,387    http-nio-8111-exec-10 : Unhandled exception: For input string: "">'>'"</script><img src="x" onerror="alert('8(')">"
java.lang.NumberFormatException: For input string: "">'>'"</script><img src="x" onerror="alert('8(')">"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
	at java.base/java.lang.Integer.parseInt(Integer.java:654) ~[?:?]
	at java.base/java.lang.Integer.parseInt(Integer.java:786) ~[?:?]
	at org.scharp.atlas.pepdb.PepDBController$DisplayPeptideGroupInformationAction.getView(PepDBController.java:445) ~[pepdb-25.3-SNAPSHOT.jar:?]
	at org.scharp.atlas.pepdb.PepDBController$DisplayPeptideGroupInformationAction.getView(PepDBController.java:438) ~[pepdb-25.3-SNAPSHOT.jar:?]
	at org.labkey.api.action.SimpleViewAction.handleRequest(SimpleViewAction.java:75) ~[api-25.3-SNAPSHOT.jar:?]
```

#### Changes
* Switch to a `NotFoundException`