### PR TITLE
Remove unnecessary HttpView.currentView() casts in JSPs

### DIFF
--- a/hdrl/src/org/labkey/hdrl/view/editRequest.jsp
+++ b/hdrl/src/org/labkey/hdrl/view/editRequest.jsp
@@ -34,7 +34,7 @@
     }
 %>
 <%
-    JspView<HDRLController.RequestForm> me = (JspView<HDRLController.RequestForm>)HttpView.currentView();
+    JspView<HDRLController.RequestForm> me = HttpView.currentView();
     ViewContext ctx = getViewContext();
     Container c = getContainer();
     User user = getUser();

--- a/hdrl/src/org/labkey/hdrl/view/sensitiveData.jsp
+++ b/hdrl/src/org/labkey/hdrl/view/sensitiveData.jsp
@@ -22,7 +22,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%@ taglib prefix="labkey" uri="http://www.labkey.org/taglib" %>
 <%
-    JspView<HDRLController.SensitiveDataForm> sensitiveDataFormJspView = (JspView<HDRLController.SensitiveDataForm>)HttpView.currentView();
+    JspView<HDRLController.SensitiveDataForm> sensitiveDataFormJspView = HttpView.currentView();
     HDRLController.SensitiveDataForm bean = sensitiveDataFormJspView.getModelBean();
     String timeWindow = String.valueOf(bean.getTimeWindowInDays());
 %>

--- a/pepdb/src/org/scharp/atlas/pepdb/view/importPeptides.jsp
+++ b/pepdb/src/org/scharp/atlas/pepdb/view/importPeptides.jsp
@@ -7,7 +7,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <div>
     <%
-        JspView<FileForm> me = (JspView<FileForm>) HttpView.currentView();
+        JspView<FileForm> me = HttpView.currentView();
         FileForm bean = me.getModelBean();
     %>
     <labkey:errors/>

--- a/pepdb/src/org/scharp/atlas/pepdb/view/importPools.jsp
+++ b/pepdb/src/org/scharp/atlas/pepdb/view/importPools.jsp
@@ -6,7 +6,7 @@
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <div>
     <%
-        JspView<PepDBController.FileForm> me = (JspView<PepDBController.FileForm>) HttpView.currentView();
+        JspView<PepDBController.FileForm> me = HttpView.currentView();
         PepDBController.FileForm bean = me.getModelBean();
     %>
 

--- a/pepdb/src/org/scharp/atlas/pepdb/view/peptideDetails.jsp
+++ b/pepdb/src/org/scharp/atlas/pepdb/view/peptideDetails.jsp
@@ -8,7 +8,7 @@
 <%@ page import="org.scharp.atlas.pepdb.model.Source" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<PeptideQueryForm> me = (JspView<PeptideQueryForm>) HttpView.currentView();
+    JspView<PeptideQueryForm> me = HttpView.currentView();
     PeptideQueryForm bean = me.getModelBean();
 %>
 <table>

--- a/pepdb/src/org/scharp/atlas/pepdb/view/peptideGroupSelect.jsp
+++ b/pepdb/src/org/scharp/atlas/pepdb/view/peptideGroupSelect.jsp
@@ -10,7 +10,7 @@
 <%@ page import="org.scharp.atlas.pepdb.model.ProteinCategory" %>
 <%@ page extends="org.labkey.api.jsp.JspBase" %>
 <%
-    JspView<PeptideQueryForm> me = (JspView<PeptideQueryForm>) HttpView.currentView();
+    JspView<PeptideQueryForm> me = HttpView.currentView();
     PeptideQueryForm bean = me.getModelBean();
     if(bean.getMessage() != null){
 %>


### PR DESCRIPTION
#### Rationale
Simple search and replace to clear warnings about unnecessary cast