### PR TITLE
Simplify and expand use of LinkBuilder factory methods

### DIFF
--- a/hdrl/src/org/labkey/hdrl/HDRLController.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLController.java
@@ -54,6 +54,7 @@ import org.labkey.api.security.permissions.InsertPermission;
 import org.labkey.api.security.permissions.ReadPermission;
 import org.labkey.api.settings.AdminConsole;
 import org.labkey.api.util.HtmlString;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.util.Path;
 import org.labkey.api.util.URLHelper;
@@ -104,7 +105,7 @@ public class HDRLController extends SpringActionController
         {
             VBox vbox = new VBox();
 
-            HtmlView submitView = new HtmlView("New Test Request", HtmlString.of(PageFlowUtil.link("Submit new test request").href(new ActionURL(EditRequestAction.class, getViewContext().getContainer()))));
+            HtmlView submitView = new HtmlView("New Test Request", HtmlString.of(LinkBuilder.labkeyLink("Submit new test request", new ActionURL(EditRequestAction.class, getViewContext().getContainer()))));
             vbox.addView(submitView);
 
             UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), HDRLQuerySchema.NAME);

--- a/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
+++ b/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
@@ -42,6 +42,7 @@ import org.labkey.api.query.SimpleUserSchema;
 import org.labkey.api.security.User;
 import org.labkey.api.security.permissions.AdminPermission;
 import org.labkey.api.security.permissions.UpdatePermission;
+import org.labkey.api.util.LinkBuilder;
 import org.labkey.api.util.PageFlowUtil;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.ViewContext;
@@ -216,13 +217,13 @@ public class HDRLQuerySchema extends SimpleUserSchema
                             {
                                 FieldKey requestFieldKey = FieldKey.fromParts("RequestId");
                                 ActionURL actionUrl = new ActionURL(HDRLController.EditRequestAction.class, c).addParameter("requestId", (Integer)ctx.get(requestFieldKey));
-                                oldWriter.write(PageFlowUtil.link("Edit").href(actionUrl).toString());
+                                oldWriter.write(LinkBuilder.labkeyLink("Edit", actionUrl).toString());
                             }
                             else
                             {
                                 ActionURL actionUrl = new ActionURL(HDRLController.RequestDetailsAction.class, c);
                                 actionUrl.addParameter("requestId", (Integer) ctx.get("requestId"));
-                                oldWriter.write(PageFlowUtil.link("View").href(actionUrl).toString());
+                                oldWriter.write(LinkBuilder.labkeyLink("View", actionUrl).toString());
                             }
                         }
                     };


### PR DESCRIPTION
#### Rationale
Using `LinkBuilder` factory methods simplifies the creation of links and provides consistency & clarity

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/6561