### PR TITLE
Move study design features into a new module

### DIFF
--- a/viscstudies/src/org/labkey/viscstudies/ViscStudyFolderType.java
+++ b/viscstudies/src/org/labkey/viscstudies/ViscStudyFolderType.java
@@ -51,7 +51,7 @@ public class ViscStudyFolderType extends MultiPortalFolderType
         super("CAVD Study", "A folder type to store vaccine studies performed for the Gates Foundation-funded CAVD",
                 null,
                 Arrays.asList(Portal.getPortalPart("Study Protocol Summary").createWebPart()),
-                getDefaultModuleSet(module, getModule("Experiment"), getModule("Study"), getModule("Pipeline")),
+                getDefaultModuleSet(module, getModule("Experiment"), getModule("Study"), getModule("Pipeline"), getModule("StudyDesign")),
                 getModule("Study"));
     }
 


### PR DESCRIPTION
#### Rationale
The `ViscStudyFolderType` set's up a study to be used with the study design tools, it is the primary folder type that the client uses to access the study design tools. 

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6686
- https://github.com/LabKey/clientModules/pull/23
- https://github.com/LabKey/testAutomation/pull/2459
- https://github.com/LabKey/customModules/pull/227
