### PR TITLE
Add study design as a dependency

### DIFF
--- a/viscstudies/build.gradle
+++ b/viscstudies/build.gradle
@@ -1,3 +1,8 @@
+import org.labkey.gradle.util.BuildUtils
 plugins {
     id 'org.labkey.build.module'
+}
+
+dependencies {
+    BuildUtils.addLabKeyDependency(project: project, config: "modules", depProjectPath: BuildUtils.getPlatformModuleProjectPath(project.gradle, "studydesign"), depProjectConfig: 'published', depExtension: 'module')
 }


### PR DESCRIPTION
#### Rationale
The `ViscStudyFolderType` already declares the `StudyDesignModule` as a dependency. This just adds the module dependency as well, and will fail server startup sooner if it doesn't exist.