### PR TITLE
Minor auto-refactor code cleanup on a massive scale

### DIFF
--- a/hdrl/src/org/labkey/hdrl/HDRLContainerListener.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLContainerListener.java
@@ -28,7 +28,6 @@ import org.labkey.api.data.SqlExecutor;
 import org.labkey.api.security.User;
 import org.labkey.api.util.ContainerUtil;
 import org.labkey.hdrl.query.LabWareQuerySchema;
-import org.labkey.remoteapi.assay.Data;
 
 import java.util.Collections;
 import java.util.Collection;

--- a/hdrl/src/org/labkey/hdrl/HDRLController.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLController.java
@@ -132,7 +132,7 @@ public class HDRLController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class RequestDetailsAction extends SimpleViewAction
+    public static class RequestDetailsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -141,7 +141,7 @@ public class HDRLController extends SpringActionController
             if (requestId != null)
             {
                 InboundRequestBean bean = HDRLManager.get().getInboundRequest(getUser(), getContainer(), Integer.parseInt(requestId));
-                JspView jsp = new JspView("/org/labkey/hdrl/view/requestDetails.jsp", bean);
+                JspView jsp = new JspView<>("/org/labkey/hdrl/view/requestDetails.jsp", bean);
                 jsp.setTitle("Test Request");
 
                 UserSchema schema = QueryService.get().getUserSchema(getUser(), getContainer(), HDRLQuerySchema.NAME);
@@ -166,7 +166,7 @@ public class HDRLController extends SpringActionController
     }
 
     @RequiresPermission(InsertPermission.class)
-    public class EditRequestAction extends SimpleViewAction<RequestForm>
+    public static class EditRequestAction extends SimpleViewAction<RequestForm>
     {
         private String _navLabel = "Create a new Test Request";
 
@@ -259,7 +259,7 @@ public class HDRLController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class VerifySpecimenAction extends ReadOnlyApiAction<VerifyForm>
+    public static class VerifySpecimenAction extends ReadOnlyApiAction<VerifyForm>
     {
         @Override
         public Object execute(VerifyForm form, BindException errors)
@@ -310,7 +310,7 @@ public class HDRLController extends SpringActionController
 
 
     @RequiresPermission(ReadPermission.class)
-    public class DownloadClinicalReportAction extends ExportAction<SpecimenForm>
+    public static class DownloadClinicalReportAction extends ExportAction<SpecimenForm>
     {
         @Override
         public void export(SpecimenForm form, HttpServletResponse response, BindException errors) throws Exception
@@ -361,7 +361,7 @@ public class HDRLController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class DownloadSpecimenTemplateAction extends ExportAction
+    public static class DownloadSpecimenTemplateAction extends ExportAction<Object>
     {
         @Override
         public void export(Object o, HttpServletResponse response, BindException errors)
@@ -385,7 +385,7 @@ public class HDRLController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class PrintPackingListAction extends SimpleViewAction<PackingListBean>
+    public static class PrintPackingListAction extends SimpleViewAction<PackingListBean>
     {
         @Override
         public ModelAndView getView(PackingListBean packingListBean, BindException errors)
@@ -483,7 +483,7 @@ public class HDRLController extends SpringActionController
 
     @AdminConsoleAction
     @RequiresPermission(AdminPermission.class)
-    public class HDRLSensitiveDataAdminAction extends FormViewAction<SensitiveDataForm>
+    public static class HDRLSensitiveDataAdminAction extends FormViewAction<SensitiveDataForm>
     {
         @Override
         public void validateCommand(SensitiveDataForm target, Errors errors)
@@ -537,7 +537,7 @@ public class HDRLController extends SpringActionController
 
     @RequiresPermission(AdminPermission.class)
     @Marshal(Marshaller.Jackson)
-    public class AddLabWareOutboundRequestAction extends MutatingApiAction<LabWareOutboundRequestForm>
+    public static class AddLabWareOutboundRequestAction extends MutatingApiAction<LabWareOutboundRequestForm>
     {
         @Override
         public Object execute(LabWareOutboundRequestForm form, BindException errors)
@@ -633,7 +633,7 @@ public class HDRLController extends SpringActionController
 
     @RequiresPermission(AdminPermission.class)
     @Marshal(Marshaller.Jackson)
-    public class AddLabWareOutboundSpecimenAction extends MutatingApiAction<LabWareOutboundSpecimenForm>
+    public static class AddLabWareOutboundSpecimenAction extends MutatingApiAction<LabWareOutboundSpecimenForm>
     {
         @Override
         public Object execute(LabWareOutboundSpecimenForm form, BindException errors) throws Exception

--- a/hdrl/src/org/labkey/hdrl/HDRLFolderType.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLFolderType.java
@@ -15,7 +15,6 @@
  */
 package org.labkey.hdrl;
 
-import org.labkey.api.module.Module;
 import org.labkey.api.module.MultiPortalFolderType;
 import org.labkey.api.view.Portal;
 

--- a/hdrl/src/org/labkey/hdrl/HDRLMaintenanceTask.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLMaintenanceTask.java
@@ -16,7 +16,6 @@
 package org.labkey.hdrl;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.labkey.api.data.DbSchema;
 import org.labkey.api.data.DbScope;
 import org.labkey.api.data.SQLFragment;

--- a/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
+++ b/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
@@ -79,7 +79,7 @@ public class HDRLQuerySchema extends SimpleUserSchema
     public static final String TABLE_LABWARE_OUTBOUND_RESULTS = "LabwareOutboundRequests";
     public static final String TABLE_LABWARE_OUTBOUND_SPECIMENS = "LabwareOutboundSpecimens";
 
-    public static final String COL_REQUEST_STATUS_ID = "RequestStatusId";;
+    public static final String COL_REQUEST_STATUS_ID = "RequestStatusId";
     public static final String COL_INBOUND_REQUEST_ID = "InboundRequestId";
     public static final String COL_ARCHIVED_REQUEST_COUNT = "ArchivedRequestCount";
 

--- a/hdrl/src/org/labkey/hdrl/query/InboundRequestTable.java
+++ b/hdrl/src/org/labkey/hdrl/query/InboundRequestTable.java
@@ -17,7 +17,6 @@ package org.labkey.hdrl.query;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.labkey.api.data.ColumnInfo;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerForeignKey;
 import org.labkey.api.data.DatabaseTableType;

--- a/hdrl/src/org/labkey/hdrl/query/InboundRequestUpdateService.java
+++ b/hdrl/src/org/labkey/hdrl/query/InboundRequestUpdateService.java
@@ -107,16 +107,16 @@ public class InboundRequestUpdateService extends DefaultQueryUpdateService
         // check that there are no duplicate barcodes
         List<String> duplicates = findDuplicates(requestId, "CustomerBarcode");
         StringBuilder message = new StringBuilder();
-        if (duplicates.size() > 0)
+        if (!duplicates.isEmpty())
         {
             message.append("Request has specimens with duplicate fields: Customer Barcode - ").append(StringUtils.join(duplicates, ", "));
         }
 
         // check that all existing DODId in the specimens in this request are unique
         duplicates = findDuplicates(requestId, "DoDId");
-        if (duplicates.size() > 0)
+        if (!duplicates.isEmpty())
         {
-            if (message.length() == 0)
+            if (message.isEmpty())
                 message.append("Request has specimens with duplicate fields: ");
             else
                 message.append("; ");
@@ -124,16 +124,16 @@ public class InboundRequestUpdateService extends DefaultQueryUpdateService
         }
         // check that all the existing SSN + FMP pairs in this request are unique
         duplicates = findDuplicates(requestId, "SSN, FMPId");
-        if (duplicates.size() > 0)
+        if (!duplicates.isEmpty())
         {
-            if (message.length() == 0)
+            if (message.isEmpty())
                 message.append("Request has specimens with duplicate fields: ");
             else
                 message.append("; ");
             message.append("SSN + FMP - ").append(StringUtils.join(duplicates, ", "));
         }
 
-        if (message.length() > 0)
+        if (!message.isEmpty())
             throw new QueryUpdateServiceException(message.toString());
 
     }

--- a/hdrl/src/org/labkey/hdrl/query/InboundSpecimenUpdateService.java
+++ b/hdrl/src/org/labkey/hdrl/query/InboundSpecimenUpdateService.java
@@ -151,28 +151,32 @@ public class InboundSpecimenUpdateService extends DefaultQueryUpdateService
                 }
             }
         }
-        if (row.get("BirthDate") != null)
+        Object birthDateObj = row.get("BirthDate");
+        if (birthDateObj != null)
         {
-            Date birthDate;
-            if (row.get("BirthDate") instanceof Date)
-                row.get("BirthDate");
+            Date birthDate = null;
+            if (birthDateObj instanceof Date d)
+                birthDate = d;
             else
             {
                 try
                 {
                     birthDate = dateFormat.parse((String) row.get("BirthDate"));
-                    if (birthDate.after(today))
-                    {
-                        errors.add("Birth date cannot be in the future");
-                    }
-                    else if ((drawDate != null) && (drawDate.before(birthDate)))
-                    {
-                        errors.add("Draw date cannot be before birth date");
-                    }
                 }
                 catch (ParseException e)
                 {
                     errors.add("Invalid birth date format");
+                }
+            }
+            if (birthDate != null)
+            {
+                if (birthDate.after(today))
+                {
+                    errors.add("Birth date cannot be in the future");
+                }
+                else if ((drawDate != null) && (drawDate.before(birthDate)))
+                {
+                    errors.add("Draw date cannot be before birth date");
                 }
             }
         }

--- a/hdrl/src/org/labkey/hdrl/query/InboundSpecimenUpdateService.java
+++ b/hdrl/src/org/labkey/hdrl/query/InboundSpecimenUpdateService.java
@@ -125,8 +125,8 @@ public class InboundSpecimenUpdateService extends DefaultQueryUpdateService
         calendar.set(Calendar.SECOND, 0);
         calendar.set(Calendar.MILLISECOND, 0);
         Date today = calendar.getTime();
-        List<String> errors = new ArrayList<String>();
-        List<String> missingFields = new ArrayList<String>();
+        List<String> errors = new ArrayList<>();
+        List<String> missingFields = new ArrayList<>();
         if (row.get("FMPId") == null)
             missingFields.add("FMP");
         if (row.get("DrawDate") == null)
@@ -153,9 +153,9 @@ public class InboundSpecimenUpdateService extends DefaultQueryUpdateService
         }
         if (row.get("BirthDate") != null)
         {
-            Date birthDate = null;
+            Date birthDate;
             if (row.get("BirthDate") instanceof Date)
-                birthDate = (Date) row.get("BirthDate");
+                row.get("BirthDate");
             else
             {
                 try

--- a/hdrl/src/org/labkey/hdrl/query/ResultTable.java
+++ b/hdrl/src/org/labkey/hdrl/query/ResultTable.java
@@ -30,7 +30,6 @@ import org.labkey.api.security.User;
 import org.labkey.api.security.UserPrincipal;
 import org.labkey.api.security.permissions.Permission;
 
-import java.sql.SQLException;
 import java.util.Map;
 
 /**

--- a/hdrl/test/src/org/labkey/test/tests/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/HDRLTest.java
@@ -66,8 +66,8 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
     public static final Locator.XPathLocator enabledSave = Locator.xpath("//a[not(contains(normalize-space(@class), 'x4-btn-disable'))]//span[text()='" + SAVE_BUTTON_TEXT + "']");
     public static final Locator.XPathLocator enabledPrintPackingList = Locator.xpath("//a[not(contains(normalize-space(@class), 'x4-btn-disable'))]//span[text()='" + PRINT_PACKING_LIST_TEXT + "']");
 
-    private static int CARRIER_COLUMN_INDEX = 2;
-    private static int STATUS_COLUMN_INDEX = 13;
+    private static final int CARRIER_COLUMN_INDEX = 2;
+    private static final int STATUS_COLUMN_INDEX = 13;
 
     @Override
     protected String getProjectName()
@@ -78,7 +78,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
     @BeforeClass
     public static void initProject()
     {
-        HDRLTest init = (HDRLTest)getCurrentTest();
+        HDRLTest init = getCurrentTest();
         init.setupFolder();
     }
 
@@ -150,7 +150,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         clickButton(SUBMIT_BUTTON_TEXT);
         DataRegionTable drt = new DataRegionTable("query", this);
         int idx = drt.getRowIndex("ShippingNumber", "testRetrievalOfResults");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         String requestId = drt.getDataAsText(idx, "RequestId");
 
         Map<String, Object> result = new HashMap<>();
@@ -236,7 +236,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         click(Locator.linkContainingText("View test requests"));
         drt = new DataRegionTable("query", this);
         idx = drt.getRowIndex("RequestId", requestId);
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         log("view test results");
         assertEquals("VIEW", drt.getDataAsText(idx, 0));
         clickAndWait(drt.link(idx, 0));
@@ -395,7 +395,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 
         DataRegionTable drt = new DataRegionTable("query", this);
         int idx = drt.getRowIndex("ShippingCarrier", "FedEx");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         clickAndWait(drt.link(idx, 0));
         log("submitting an existing request");
         waitForElement(Locator.tagContainingText("div", "222-33-4444"));
@@ -404,7 +404,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 
         drt = new DataRegionTable("query", this);
         idx = drt.getRowIndex("ShippingCarrier", "FedEx");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         Assert.assertFalse(drt.getDataAsText(idx, "Submitted By").trim().isEmpty()); // "submitted by" field should be filled in
         Assert.assertFalse(drt.getDataAsText(idx, "Submitted").trim().isEmpty()); // submitted date should be filled in
 
@@ -423,7 +423,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         clickAndWait(Locator.linkContainingText("View test requests"));
         drt = new DataRegionTable("query", this);
         idx = drt.getRowIndex("ShippingCarrier", "FedEx");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         log("ensure submitted requests are still editable by admins");
         assertEquals("VIEW", drt.getDataAsText(idx, 0));
         clickAndWait(drt.link(idx, 0));
@@ -454,7 +454,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         log("Edit the submitted request as admin");
         DataRegionTable drt = new DataRegionTable("query", this);
         int idx = drt.getRowIndex("ShippingNumber", "testEditSubmittedRequest");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         assertEquals("Submitted", drt.getDataAsText(idx, STATUS_COLUMN_INDEX));
         String submittedDate = drt.getDataAsText(idx, 6).trim();
 
@@ -476,7 +476,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         log("Test that not saving request does not change anything");
         clickButton("Cancel", 0); // takes you back to the view test requests page
         idx = drt.getRowIndex("ShippingNumber", "testEditSubmittedRequest");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         assertEquals("Submitted", drt.getDataAsText(idx, STATUS_COLUMN_INDEX));
         assertNotEquals("DHL", drt.getDataAsText(idx, CARRIER_COLUMN_INDEX));
         assertEquals("EDIT", drt.getDataAsText(idx, 0));
@@ -491,7 +491,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 
         log("Test that saving request does not change the request status");
         idx = drt.getRowIndex("ShippingNumber", "testEditSubmittedRequest");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         assertEquals("Submitted", drt.getDataAsText(idx, STATUS_COLUMN_INDEX));
         assertEquals("DHL", drt.getDataAsText(idx, CARRIER_COLUMN_INDEX));
         // submitted date should still be the same
@@ -528,7 +528,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         click(Locator.linkWithText("View test requests"));
         DataRegionTable drt = new DataRegionTable("query", this);
         int idx = drt.getRowIndex("ShippingNumber", "testRetrievalOfResults");
-        assertNotEquals(idx, -1);
+        assertNotEquals(-1, idx);
         String requestId = drt.getDataAsText(idx, "RequestId");
         Assert.assertEquals("Archived", drt.getDataAsText(idx, "Status"));
         List<String> specimenIds = getSpecimenIds(requestId, "hdrl", "InboundSpecimen", "RowId");
@@ -600,7 +600,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         for (Map<String, String> expectedRow : expectedRows)
         {
             int idx = drt.getRowIndex(key, expectedRow.get(key));
-            assertNotEquals(String.format("Didn't find row with %s = %s", key, expectedRow.get(key)), idx, -1);
+            assertNotEquals(String.format("Didn't find row with %s = %s", key, expectedRow.get(key)), -1, idx);
 
             Map<String, String> actualRow = new HashMap<>();
             for (Map.Entry<String, String> field : expectedRow.entrySet())

--- a/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsController.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsController.java
@@ -96,7 +96,7 @@ public class MS2ExtensionsController extends SpringActionController
     }
 
     @RequiresPermission(AdminOperationsPermission.class)
-    public class UpdatePeptideCountsAction extends SimpleViewAction<Object>
+    public static class UpdatePeptideCountsAction extends SimpleViewAction<Object>
     {
         @Override
         public ModelAndView getView(Object o, BindException errors)
@@ -105,7 +105,7 @@ public class MS2ExtensionsController extends SpringActionController
             {
                 List<DOM.Renderable> warnings = new ArrayList<>();
                 updatePeptideCounts(warnings, getContainer());
-                if (warnings.size() == 0)
+                if (warnings.isEmpty())
                 {
                     return new HtmlView(DOM.DIV("Success!"));
                 }
@@ -139,7 +139,7 @@ public class MS2ExtensionsController extends SpringActionController
     }
 
     @RequiresPermission(ReadPermission.class)
-    public class SetPreferencesAction extends MutatingApiAction<SimpleApiJsonForm>
+    public static class SetPreferencesAction extends MutatingApiAction<SimpleApiJsonForm>
     {
         @Override
         public ApiResponse execute(SimpleApiJsonForm simpleApiJsonForm, BindException errors)

--- a/ms2extensions/src/org/labkey/ms2extensions/PeptideCountPepXmlDataHandler.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/PeptideCountPepXmlDataHandler.java
@@ -16,7 +16,6 @@
 package org.labkey.ms2extensions;
 
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.LogManager;
 import org.jetbrains.annotations.Nullable;
 import org.labkey.api.data.Container;
 import org.labkey.api.exp.ExperimentDataHandler;

--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBBaseController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBBaseController.java
@@ -215,7 +215,7 @@ public class PepDBBaseController extends SpringActionController
             {
                 if (StringUtils.trimToNull(qValue) == null)
                     errors.reject(null, "The Peptide Id range must be entered.");
-                if (qValue != null && qValue.length() > 0)
+                if (qValue != null && !qValue.isEmpty())
                 {
                     if (!(qValue.matches("\\d+-\\d+")))
                     {
@@ -423,7 +423,7 @@ public class PepDBBaseController extends SpringActionController
                     errors.reject(null, "File name must end with in .txt.\nFile should be tab delimited text file and the number of field vary depending on file type.");
                 }
             }
-            if (getActionType() == null || getActionType().length() == 0)
+            if (getActionType() == null || getActionType().isEmpty())
                 errors.reject(null, "File Type is required");
             if(errors.getErrorCount() > 0)
                 return false;

--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBManager.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBManager.java
@@ -34,8 +34,8 @@ import java.util.HashMap;
 public class PepDBManager
 {
 
-    private static Logger log = LogManager.getLogger(PepDBManager.class);
-    private static PepDBSchema schema = PepDBSchema.getInstance();
+    private static final Logger log = LogManager.getLogger(PepDBManager.class);
+    private static final PepDBSchema schema = PepDBSchema.getInstance();
     /**
      * Static class
      */
@@ -78,7 +78,6 @@ public class PepDBManager
     }
 
     /**
-     * @param peptideGroup
      * @return the number of peptides in a given group
      */
     public static Integer getCount(Integer peptideGroup)
@@ -319,7 +318,7 @@ public class PepDBManager
 
     public static PeptideGroup getPeptideGroupByName(PeptideGroup pg)
     {
-        PeptideGroup [] groups = null;
+        PeptideGroup [] groups;
         TableInfo tInfo = schema.getTableInfoPeptideGroups();
         SQLFragment sql = new SQLFragment("SELECT * FROM "+tInfo+" WHERE UPPER(peptide_group_name) = ? ");
         sql.add(pg.getPeptide_group_name().trim().toUpperCase());

--- a/pepdb/src/org/scharp/atlas/pepdb/PeptideImporter.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PeptideImporter.java
@@ -84,7 +84,7 @@ public class PeptideImporter
     {
         if(peptideIdList == null)
         {
-            peptideIdList = new ArrayList<Peptides>();
+            peptideIdList = new ArrayList<>();
             Peptides[] peptides = PepDBManager.getPeptides();
             for(Peptides p: peptides)
             {
@@ -114,12 +114,12 @@ public class PeptideImporter
             getOptimalElitopeListMap();
             HashMap<String,Peptides> peptideSequenceMap = PepDBManager.getPeptideSequenceMap();
             int lineNo =1;
-            ArrayList<Peptides> newpeptidesList =new ArrayList<Peptides>();
-            HashMap<String,String> lineMap = new HashMap<String,String>();
+            ArrayList<Peptides> newpeptidesList = new ArrayList<>();
+            HashMap<String,String> lineMap = new HashMap<>();
             while((line = br.readLine()) != null)
             {
                 lineNo++;
-                if(line.length()>0)
+                if(!line.isEmpty())
                 {
                     if(validateLine(line,errors,lineNo))
                     {
@@ -143,7 +143,7 @@ public class PeptideImporter
             {
                 if(peptideSequenceMap.containsKey(p.getPeptide_sequence()))
                 {
-                    if(p.getPeptide_id() == null || p.getPeptide_id().toString().length() == 0)
+                    if(p.getPeptide_id() == null || p.getPeptide_id().toString().isEmpty())
                         p.setPeptide_id(peptideSequenceMap.get(p.getPeptide_sequence()).getPeptide_id());
                     insertGroups(p,user);
                     resultPeptides.add(p);
@@ -175,7 +175,7 @@ public class PeptideImporter
                         parent.setPeptide_id(p.getPeptide_id());
                         Parent dbParent = PepDBManager.parentExists(parent);
                         if(dbParent == null)
-                            dbParent = PepDBManager.insertParent(user,parent);
+                            PepDBManager.insertParent(user, parent);
                         if(!par.isParent())
                         {
                             par.setParent(true);
@@ -210,10 +210,10 @@ public class PeptideImporter
         }
         if(fields.length < 8 )
             errors.reject(null,"Line number : "+lineNo+"must have 8-10 fields.The Peptides File has to be tab delimited and should have atleast 8 fields.");
-        else if((fields[0] == null || fields[0].length() == 0) || (fields[1] == null || fields[1].length() == 0)||
-                (fields[2] == null || fields[2].length() == 0) || (fields[3] == null || fields[3].length() == 0)||
-                (fields[4] == null || fields[4].length() == 0) || (fields[5] == null || fields[5].length() == 0)||
-                (fields[6] == null || fields[6].length() == 0) || (fields[7] == null || fields[7].length() == 0))
+        else if((fields[0] == null || fields[0].isEmpty()) || (fields[1] == null || fields[1].isEmpty())||
+                (fields[2] == null || fields[2].isEmpty()) || (fields[3] == null || fields[3].isEmpty())||
+                (fields[4] == null || fields[4].isEmpty()) || (fields[5] == null || fields[5].isEmpty())||
+                (fields[6] == null || fields[6].isEmpty()) || (fields[7] == null || fields[7].isEmpty()))
             errors.reject(null,"Line number : "+lineNo+" is missing one of the field values \n" +
                     "'PEPTIDE SEQUENCE','IS CHILD','PROTEIN CATEGORY','PEPTIDE GROUP','ID','SEQUENCE LENGTH',\n" +
                     "'AASTART','AAEND','IN A LIST' and 'HLA RESTRICTION'.");
@@ -255,12 +255,12 @@ public class PeptideImporter
                 if(!fields[3].trim().toUpperCase().equals("OPTIMAL EPITOPES"))
                     errors.reject(null,"Line number : "+lineNo+" If the peptide is a child then the Peptide Group: "+fields[2].trim().toUpperCase()+
                             " must be 'OPTIMAL EPITOPES'.");
-                if(fields[8] == null || fields[8].length() == 0 || !optimalElitopeListMap.containsKey(fields[8].trim().toUpperCase()))
+                if(fields[8] == null || fields[8].isEmpty() || !optimalElitopeListMap.containsKey(fields[8].trim().toUpperCase()))
                     errors.reject(null,"Line number : "+lineNo+" If the peptide is a child then the value for 'IN A LIST' is required and must pre exist in database.Contact SCHARP to add new Optimal Epitope List");
             }
             else
             {
-                if((fields[8] != null && fields[8].length() != 0) || (fields[9] != null && fields[9].length() != 0))
+                if((fields[8] != null && !fields[8].isEmpty()) || (fields[9] != null && !fields[9].isEmpty()))
                     errors.reject(null,"Line number : "+lineNo+" If the peptide is not a child then the values for 'IN A LIST' and 'HLA RESTRICTION' are not required.");
             }
         }
@@ -287,9 +287,9 @@ public class PeptideImporter
         peptide.setSequence_length(validateInteger(fields[5].trim()));
         peptide.setAmino_acid_start_pos(validateInteger(fields[6].trim()));
         peptide.setAmino_acid_end_pos(validateInteger(fields[7].trim()));
-        if(fields[8]!=null && fields[8].trim().length() !=0)
+        if(fields[8]!=null && !fields[8].trim().isEmpty())
             peptide.setOptimal_epitope_list_id(optimalElitopeListMap.get(fields[8].trim().toUpperCase()).getOptimal_epitope_list_id());
-        if(fields[9] !=null && fields[9].trim().length() !=0)
+        if(fields[9] !=null && !fields[9].trim().isEmpty())
         {
             String  hla = fields[9].trim();
             if(hla.charAt(0) == '"')
@@ -322,7 +322,7 @@ public class PeptideImporter
         else{
             for(int i = 0;i <10;i++)
             {
-                if(fields[i] ==null || fields[i].length() == 0)
+                if(fields[i] ==null || fields[i].isEmpty())
                     errors.reject(null,"Line number : 1 in the Peptides file has to be tab delimited and should have 10 fields.\n"+
                             "'PEPTIDE SEQUENCE','IS CHILD','PROTEIN CATEGORY','PEPTIDE GROUP','ID','SEQUENCE LENGTH',\n" +
                             "'AASTART','AAEND','IN A LIST' and 'HLA RESTRICTION'.\n"+

--- a/pepdb/src/org/scharp/atlas/pepdb/PoolImporter.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PoolImporter.java
@@ -99,12 +99,12 @@ public class PoolImporter
                     return false;
                 getPeptidePoolMap();
                 getPoolTypeMap();
-                ArrayList<PeptidePool> newPPools = new ArrayList<PeptidePool>();
+                ArrayList<PeptidePool> newPPools = new ArrayList<>();
                 int lineNo =1;
                 while((line = br.readLine()) != null)
                 {
                     lineNo++;
-                    if(line.trim().length()>0)
+                    if(!line.trim().isEmpty())
                     {
                         if(validateLine(line,errors,lineNo))
                         {
@@ -124,7 +124,7 @@ public class PoolImporter
                     if(pPool.getPool_type_id() != poolTypeMap.get("POOL").getPool_type_id())
                     pPool.setParent_pool_id(peptidePoolMap.get(pPool.getParent_pool_name()).getPeptide_pool_id());
                     PeptidePool dbPeptidePool = null;
-                    if(peptidePoolMap.get(pPool.getPeptide_pool_name().trim().toUpperCase()).getPeptide_pool_id() == null || peptidePoolMap.get(pPool.getPeptide_pool_name().trim().toUpperCase()).getPeptide_pool_id().toString().length() == 0)
+                    if(peptidePoolMap.get(pPool.getPeptide_pool_name().trim().toUpperCase()).getPeptide_pool_id() == null || peptidePoolMap.get(pPool.getPeptide_pool_name().trim().toUpperCase()).getPeptide_pool_id().toString().isEmpty())
                         dbPeptidePool= PepDBManager.insertPeptidePool(user,pPool);
                     if(dbPeptidePool != null)
                         peptidePoolMap.put(dbPeptidePool.getPeptide_pool_name().trim().toUpperCase(),dbPeptidePool);
@@ -149,12 +149,12 @@ public class PoolImporter
                 getPeptidePoolMap();
                 getPeptideSequenceMap();
                 getPeptideGroupMap();
-                ArrayList<PeptidePoolAssignment> newpeptidesInPools = new ArrayList<PeptidePoolAssignment>();
-                HashMap<Integer, ArrayList<Integer>> newpoolPeptides = new HashMap<Integer,ArrayList<Integer>>();
+                ArrayList<PeptidePoolAssignment> newpeptidesInPools = new ArrayList<>();
+                HashMap<Integer, ArrayList<Integer>> newpoolPeptides = new HashMap<>();
                 while((line = br.readLine()) != null)
                 {
                     lineNo++;
-                    if(line.length()>0)
+                    if(!line.isEmpty())
                     {
                         if(validatePPLine(line,errors,lineNo,newpoolPeptides))
                         {
@@ -166,7 +166,7 @@ public class PoolImporter
                                      newpoolPeptides.get(poolAssign.getPeptide_pool_id()).add(poolAssign.getPeptide_id());
                                 else
                                 {
-                                  ArrayList<Integer> peps = new ArrayList<Integer>();
+                                  ArrayList<Integer> peps = new ArrayList<>();
                                   peps.add(poolAssign.getPeptide_id());
                                   newpoolPeptides.put(poolAssign.getPeptide_pool_id(),peps);
                                 }
@@ -219,7 +219,7 @@ public class PoolImporter
         PeptidePool pPool = new PeptidePool();
         pPool.setPeptide_pool_name(fields[0].trim());
         pPool.setPool_type_id(poolTypeMap.get(fields[1].trim().toUpperCase()).getPool_type_id());
-        if(fields[2] != null && fields[2].trim().toUpperCase() != null && fields[2].trim().toUpperCase().length() != 0)
+        if(fields[2] != null && fields[2].trim().toUpperCase() != null && !fields[2].trim().toUpperCase().isEmpty())
         pPool.setParent_pool_name(fields[2].trim().toUpperCase());
         if(fields[1].trim().toUpperCase().equalsIgnoreCase("MATRIX"))
         pPool.setMatrix_peptide_pool_id(fields[3].trim());
@@ -240,7 +240,7 @@ public class PoolImporter
             errors.reject(null,"Line number : "+lineNo+"must have 2 fields.The Pool Description File has to be tab delimited and must have the fields 'POOL NAME' and 'POOL TYPE'.");
         else
         {
-            if((fields[0] == null || fields[0].trim().length() == 0) || (fields[1] == null || fields[1].trim().length() == 0))
+            if((fields[0] == null || fields[0].trim().isEmpty()) || (fields[1] == null || fields[1].trim().isEmpty()))
                 errors.reject(null,"Line number : "+lineNo+" is missing one of the required field values \n" +
                         "'POOL NAME' and 'POOL TYPE'.");
             else   {
@@ -252,23 +252,23 @@ public class PoolImporter
                             " that does not exist in the database. Check the file and upload again or Contact SCHARP to add new Pool Type.");
                 else
                 {
-                    if (fields[1].trim().toUpperCase().equalsIgnoreCase("MATRIX") && (fields[3] == null || fields[3].trim().length() == 0))
+                    if (fields[1].trim().toUpperCase().equalsIgnoreCase("MATRIX") && (fields[3] == null || fields[3].trim().isEmpty()))
                      errors.reject(null,"Line number : "+lineNo+" is missing 'MATRIX POOL ID' " + fields[1] +
                             " for 'POOL TYPE' 'MATRIX'. Check the file and upload again or Contact SCHARP to add new Pool Type.");
 
-                    if (!fields[1].trim().toUpperCase().equalsIgnoreCase("MATRIX") && (fields[3] != null && fields[3].trim().length() != 0))
+                    if (!fields[1].trim().toUpperCase().equalsIgnoreCase("MATRIX") && (fields[3] != null && !fields[3].trim().isEmpty()))
                      errors.reject(null,"Line number : "+lineNo+" has 'MATRIX POOL ID' " + fields[1] +
                             " for 'POOL TYPE' other than 'MATRIX' which is not expected. Check the file and upload again or Contact SCHARP to add new Pool Type.");
 
-                    if (fields[1].trim().toUpperCase().equalsIgnoreCase("POOL") && (fields[2] != null && fields[2].trim().length() != 0))
+                    if (fields[1].trim().toUpperCase().equalsIgnoreCase("POOL") && (fields[2] != null && !fields[2].trim().isEmpty()))
                      errors.reject(null,"Line number : "+lineNo+" has 'PARENT POOL NAME' " + fields[1] +
                             " for 'POOL TYPE' 'POOL' which is not expected. Check the file and upload again or Contact SCHARP to add new Pool Type.");
 
-                    if ((!fields[1].trim().toUpperCase().equalsIgnoreCase("POOL") && !fields[1].trim().toUpperCase().equalsIgnoreCase("OTHER")) && (fields[2] == null || fields[2].trim().length() == 0))
+                    if ((!fields[1].trim().toUpperCase().equalsIgnoreCase("POOL") && !fields[1].trim().toUpperCase().equalsIgnoreCase("OTHER")) && (fields[2] == null || fields[2].trim().isEmpty()))
                      errors.reject(null,"Line number : "+lineNo+" is missing 'PARENT POOL NAME' " + fields[1] +
                             " for 'POOL TYPE' other than 'POOL' and 'OTHER'. Check the file and upload again or Contact SCHARP to add new Pool Type.");
 
-                    else if(fields[2] != null && fields[2].trim().length() != 0)
+                    else if(fields[2] != null && !fields[2].trim().isEmpty())
                     {
                     if(!peptidePoolMap.containsKey(fields[2].trim().toUpperCase()))
                       errors.reject(null,"Line number : "+lineNo+" contains the 'PARENT POOL NAME' = '" + fields[2] +
@@ -303,7 +303,7 @@ public class PoolImporter
             errors.reject(null,"Line number : "+lineNo+"must have 3 fields.The Peptides In Pool File has to be tab delimited and must have the fields 'POOL NAME', 'PEPTIDE SEQUENCE' and , 'PEPTIDE GROUP'.");
         else
         {
-            if((fields[0] == null || fields[0].trim().length() == 0) || (fields[1] == null || fields[1].trim().length() == 0) || (fields[2] == null || fields[2].trim().length() == 0))
+            if((fields[0] == null || fields[0].trim().isEmpty()) || (fields[1] == null || fields[1].trim().isEmpty()) || (fields[2] == null || fields[2].trim().isEmpty()))
                 errors.reject(null,"Line number : "+lineNo+" is missing one of the field values \n" +
                         "'POOL NAME', 'PEPTIDE SEQUENCE' and , 'PEPTIDE GROUP'.");
             else   {
@@ -330,8 +330,8 @@ public class PoolImporter
                         {
                             Integer[] peptidesInParent = PepDBManager.getPeptidesInPool(pp.getParent_pool_id());
 
-                            if( (peptidesInParent == null && (newPoolPeptides.size() == 0 || !newPoolPeptides.containsKey(pp.getParent_pool_id())))||(peptidesInParent != null && !Arrays.asList( peptidesInParent).contains(p.getPeptide_id())) ||
-                                    (newPoolPeptides.size() != 0 && newPoolPeptides.containsKey(pp.getParent_pool_id()) && !newPoolPeptides.get(pp.getParent_pool_id()).contains(p.getPeptide_id())))
+                            if( (peptidesInParent == null && (newPoolPeptides.isEmpty() || !newPoolPeptides.containsKey(pp.getParent_pool_id())))||(peptidesInParent != null && !Arrays.asList( peptidesInParent).contains(p.getPeptide_id())) ||
+                                    (!newPoolPeptides.isEmpty() && newPoolPeptides.containsKey(pp.getParent_pool_id()) && !newPoolPeptides.get(pp.getParent_pool_id()).contains(p.getPeptide_id())))
                                 errors.reject(null,"Line number : "+lineNo+" contains the 'PEPTIDE SEQUENCE' = '" + fields[1] +
                             "' which is not in parent pool in the database or prior to this row. Check the file and upload again.");
 
@@ -356,10 +356,10 @@ public class PoolImporter
                         "The header line does not match this format. Please check the file and try to upload again.");
             else
             {
-                if(fields[0] ==null || fields[0].trim().length() == 0
-                        || fields[1] ==null || fields[1].trim().length() == 0
-                        || fields[2] ==null || fields[2].trim().length() == 0
-                        || fields[3] ==null || fields[3].trim().length() == 0)
+                if(fields[0] ==null || fields[0].trim().isEmpty()
+                        || fields[1] ==null || fields[1].trim().isEmpty()
+                        || fields[2] ==null || fields[2].trim().isEmpty()
+                        || fields[3] ==null || fields[3].trim().isEmpty())
                     errors.reject(null,"Line number : 1 must be tab delimited with the fields 'Pool Name','Pool Type','Parent Pool Name' and 'Matrix Pool Id' in the Pool Descriptions file.\n"+
                             "One of the fields in header line is null or empty. Please check the file and try to upload again.");
                 else
@@ -385,7 +385,7 @@ public class PoolImporter
                         "The header line does not match this format. Please check the file and try to upload again.");
             else
             {
-                if(fields[0] ==null || fields[0].trim().length() == 0 ||fields[1] ==null || fields[1].trim().length() == 0 || fields[2] ==null || fields[2].trim().length() == 0)
+                if(fields[0] ==null || fields[0].trim().isEmpty() ||fields[1] ==null || fields[1].trim().isEmpty() || fields[2] ==null || fields[2].trim().isEmpty())
                     errors.reject(null,"Line number : 1 must be tab delimited with the fields 'POOL NAME','PEPTIDE SEQUENCE' and 'PEPTIDE GROUP'in the Peptides in Pool file.\n"+
                             "One of the fields in header line is null or empty. Please check the file and try to upload again.");
                 else

--- a/pepdb/src/org/scharp/atlas/pepdb/model/PeptidePool.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/model/PeptidePool.java
@@ -22,7 +22,7 @@ public class PeptidePool extends Entity
     private Integer parent_pool_id;
     private String parent_pool_name;
     private String matrix_peptide_pool_id;
-    private static Logger log = LogManager.getLogger(PeptidePool.class);
+    private static final Logger log = LogManager.getLogger(PeptidePool.class);
 
     public PeptidePool()
     {

--- a/pepdb/test/src/org/labkey/test/tests/pepdb/PepDBModuleTest.java
+++ b/pepdb/test/src/org/labkey/test/tests/pepdb/PepDBModuleTest.java
@@ -83,7 +83,6 @@ public class PepDBModuleTest extends BaseWebDriverTest implements PostgresOnlyTe
     /**
      * Set which view in this folder should be the default
      *
-     * @param moduleName
      */
     void setDefaultModule(String moduleName)
     {


### PR DESCRIPTION
#### Rationale
We can cleanup tens of thousands of warnings across our codebase with IntelliJ's autorefactors. In some cases, this adopts newer, leaner syntax. In others, it simply removes code that's not serving any purpose.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/6742

#### Changes
- Auto-refactors
  - Eliminate redundant toString()
  - Eliminate redundant cast
  - Empty JavaDoc annotations
  - Member variable can be final
  - length() and size() -> isEmpty()
  - Add missing @Override
  - Class can be static
  - Remove unused imports
  - toArray() passed array length
  - Remove unnecessary semicolon
  - Explicit type syntax can be replaced by <>
  - Redundant access modifiers
  - Remove redundant initializer
  - "".equals() -> isEmpty()
  - StringBuilder can be replaced by String
  - Fix misordered arguments to assertEquals()
  - StringUtils.defaultString() - Objects.toString()
  - Cast can be replaced with pattern variable
  - Collapse identical catch blocks
  - Type may be primitive
- Manual fixups
  - Delete unused GWT code
  - Improve generics
  - new UnexpectedException() -> UnexpectedException.wrap()


