### PR TITLE
Remove deprecated methods from SQLFragment

### DIFF
--- a/hdrl/src/org/labkey/hdrl/query/InboundRequestUpdateService.java
+++ b/hdrl/src/org/labkey/hdrl/query/InboundRequestUpdateService.java
@@ -148,7 +148,7 @@ public class InboundRequestUpdateService extends DefaultQueryUpdateService
     private static List<String> findDuplicates(Integer requestId, String fields)
     {
         SQLFragment sql = new SQLFragment("SELECT ")
-                .append(fields).append(" FROM hdrl.inboundspecimen WHERE inboundrequestid = ").append(requestId);
+                .append(fields).append(" FROM hdrl.inboundspecimen WHERE inboundrequestid = ?").add(requestId);
         for (String field : fields.split(", "))
         {
             sql.append(" AND ").append(field).append(" IS NOT NULL ");


### PR DESCRIPTION
#### Rationale
Deprecation is good, removal is even better.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7080

#### Changes
* Use JDBC parameter instead
