### PR TITLE
Fix column identifiers in HDRLTest

### DIFF
--- a/hdrl/test/src/org/labkey/test/tests/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/HDRLTest.java
@@ -392,10 +392,10 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 
         log("edit an existing request");
         goToProjectHome();
-        click(Locator.linkContainingText("View test requests"));
+        clickAndWait(Locator.linkContainingText("View test requests"));
 
         DataRegionTable drt = new DataRegionTable("query", this);
-        int idx = drt.getRowIndex("ShippingCarrier", "FedEx");
+        int idx = drt.getRowIndex("ShippingCarrierId", "FedEx");
         assertNotEquals(-1, idx);
         clickAndWait(drt.link(idx, 0));
         log("submitting an existing request");
@@ -404,7 +404,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         clickButton(SUBMIT_BUTTON_TEXT);
 
         drt = new DataRegionTable("query", this);
-        idx = drt.getRowIndex("ShippingCarrier", "FedEx");
+        idx = drt.getRowIndex("ShippingCarrierId", "FedEx");
         assertNotEquals(-1, idx);
         Assert.assertFalse(drt.getDataAsText(idx, "Submitted By").trim().isEmpty()); // "submitted by" field should be filled in
         Assert.assertFalse(drt.getDataAsText(idx, "Submitted").trim().isEmpty()); // submitted date should be filled in
@@ -423,7 +423,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         goToProjectHome();
         clickAndWait(Locator.linkContainingText("View test requests"));
         drt = new DataRegionTable("query", this);
-        idx = drt.getRowIndex("ShippingCarrier", "FedEx");
+        idx = drt.getRowIndex("ShippingCarrierId", "FedEx");
         assertNotEquals(-1, idx);
         log("ensure submitted requests are still editable by admins");
         assertEquals("VIEW", drt.getDataAsText(idx, 0));
@@ -526,7 +526,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         getDriver().close();
         switchToMainWindow();
         goToProjectHome();
-        click(Locator.linkWithText("View test requests"));
+        clickAndWait(Locator.linkWithText("View test requests"));
         DataRegionTable drt = new DataRegionTable("query", this);
         int idx = drt.getRowIndex("ShippingNumber", "testRetrievalOfResults");
         assertNotEquals(-1, idx);
@@ -641,9 +641,9 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
     protected void setTimeWindow()
     {
         goToAdminConsole();
-        click(Locator.linkWithText("HDRL Sensitive Data"));
+        clickAndWait(Locator.linkWithText("HDRL Sensitive Data"));
         setFormElement(Locator.name("timeWindowInDays"), "0");
-        click(Locator.linkWithSpan("Save"));
+        clickAndWait(Locator.linkWithSpan("Save"));
     }
 
     @Override

--- a/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.labkey.test.tests;
+package org.labkey.test.tests.hdrl;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -29,7 +29,7 @@ import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.Git;
+import org.labkey.test.categories.CustomModules;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
-@Category({Git.class})
+@Category({CustomModules.class})
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 {

--- a/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
@@ -29,7 +29,7 @@ import org.labkey.test.Locators;
 import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
-import org.labkey.test.categories.CustomModules;
+import org.labkey.test.categories.Git;
 import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.LoggedParam;
@@ -50,7 +50,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 import static org.labkey.test.util.PermissionsHelper.READER_ROLE;
 
-@Category({CustomModules.class})
+@Category({Git.class}) // Requires dataintegration module
 @BaseWebDriverTest.ClassTimeout(minutes = 8)
 public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 {

--- a/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
@@ -212,7 +212,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         specimen1.put("SampleIntegrity", "Hemolyzed");
         specimen1.put("TestResult", "HIV Negative");
         specimen1.put("CustomerCode", "5B");
-        specimen1.put("RequestStatus", "Completed");
+        specimen1.put("RequestStatusId", "Completed");
         specimen1.put("ModifiedResultFlag", "F");
 
         Map<String, String> specimen2 = new HashMap<>();
@@ -220,7 +220,7 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         specimen2.put("RequestId", requestId);
         specimen2.put("SpecimenId", specimenIds.get(1));
         specimen2.put("Received", "2015-06-01 00:00");
-        specimen2.put("RequestStatus", "Exception");
+        specimen2.put("RequestStatusId", "Exception");
         specimen2.put("ModifiedResultFlag", "F");
 
         List<Map<String, String>> specimens = new ArrayList<>();


### PR DESCRIPTION
#### Rationale
This test is unable to find these columns by their label (not sure why). Hopefully, name works.
```
org.openqa.selenium.NoSuchElementException: No column: RequestStatus
  at app//org.labkey.test.util.DataRegionTable$Elements.getColumnIndex(DataRegionTable.java:1569)
  at app//org.labkey.test.util.DataRegionTable.getColumnIndexStrict(DataRegionTable.java:428)
  at app//org.labkey.test.util.DataRegionTable.getDataAsText(DataRegionTable.java:682)
  at app//org.labkey.test.tests.HDRLTest.verifyDataRegionRows(HDRLTest.java:609)
  at app//org.labkey.test.tests.HDRLTest.testRetrievalOfResultsAndArchiving(HDRLTest.java:232)
```

#### Related Pull Requests
* N/A

#### Changes
* Update column identifiers for "RequestStatus" and "ShippingCarrier"
