### PR TITLE
Update column names and disable time zone shifting for HDRLTest

### DIFF
--- a/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
+++ b/hdrl/test/src/org/labkey/test/tests/hdrl/HDRLTest.java
@@ -96,6 +96,12 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
         super.doCleanup(afterTest);
     }
 
+    @Override
+    protected boolean allowTimeZoneShifting()
+    {
+        return false; // Ext forms need to be updated to handle time zones properly
+    }
+
     private void addTestResultData(Map<String, Object> requestData, List<Map<String, Object>> specimenData)
     {
         addRequestResultData(requestData);
@@ -244,11 +250,11 @@ public class HDRLTest extends BaseWebDriverTest implements PostgresOnlyTest
 
         waitForElement(Locator.tagContainingText("td", specimenIds.get(0)));
         drt = new DataRegionTable("query", this);
-        idx = drt.getRowIndex("SpecimenId", specimenIds.get(0));
+        idx = drt.getRowIndex("RowId", specimenIds.get(0));
         assertEquals("Download", drt.getDataAsText(idx, 0));
         assertEquals( Arrays.asList("Completed","Exception"),drt.getColumnDataAsText("Status"));
-        assertEquals( Arrays.asList("F","F"),drt.getColumnDataAsText("ResultModified"));
-        assertEquals( Arrays.asList("7777","8888"),drt.getColumnDataAsText("CustomerBarcode"));
+        assertEquals( Arrays.asList("F","F"),drt.getColumnDataAsText("ModifiedResultFlag"));
+        assertEquals( Arrays.asList("7777","8888"),drt.getColumnDataAsText("CustomerBarCode"));
         assertEquals( Arrays.asList("Johnston","Johnston"),drt.getColumnDataAsText("LastName"));
         assertEquals( Arrays.asList("Jack","Fred"),drt.getColumnDataAsText("FirstName"));
         assertEquals( Arrays.asList("Sparrow"," "),drt.getColumnDataAsText("MiddleName"));


### PR DESCRIPTION
#### Rationale
I figured out why this started failing on TeamCity. It requires dataintegration, so doesn't run in community suites but this repository wasn't included in the premium suites until recently. After adding this repo to the premium suites and it revealed a couple of  problems with this test.
The forms in this module don't handle time zone shifting correctly. This is similar to the problems we have with EHR Ext forms. Like those tests, the fix is to disable time zone shifting for the test.
`DataRegionTable` no longer compensates for missing spaces when referencing columns by label. I've updated the test to use the columns' names instead.

#### Related Pull Requests
* https://github.com/LabKey/testAutomation/pull/2281
* https://github.com/LabKey/testAutomation/pull/2513

#### Changes
* Update column names in HDRLTest
* Disable time zone shifting in HDRLTest
