### PR TITLE
Replace AbstractContainerListener with ContainerListener default

### DIFF
--- a/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
@@ -46,10 +46,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-/**
- * User: jeckels
- * Date: 1/16/13
- */
 public class MS2ExtensionsModule extends DefaultModule
 {
     public static final String NAME = "MS2Extensions";
@@ -121,7 +117,7 @@ public class MS2ExtensionsModule extends DefaultModule
 
         AdminConsole.addLink(AdminConsole.SettingsLinkType.Premium, "update peptide counts", new ActionURL(MS2ExtensionsController.UpdatePeptideCountsAction.class, ContainerManager.getRoot()), AdminOperationsPermission.class);
 
-        ContainerManager.addContainerListener(new ContainerManager.AbstractContainerListener()
+        ContainerManager.addContainerListener(new ContainerManager.ContainerListener()
         {
             @Override
             public void containerDeleted(Container c, User user)


### PR DESCRIPTION
#### Rationale
Reduce boilerplate and empty methods. Most implementations only override one or two methods.

#### Related Pull Requests
- https://github.com/LabKey/platform/pull/7154

#### Changes
- Remove `AbstractContainerListener`. Replace with default implementation of methods on `ContainerListener` interface.