### PR TITLE
Handle invalid request ID in HDRLQuerySchema

### DIFF
--- a/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
+++ b/hdrl/src/org/labkey/hdrl/query/HDRLQuerySchema.java
@@ -19,6 +19,7 @@ package org.labkey.hdrl.query;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.labkey.api.action.ApiUsageException;
 import org.labkey.api.data.Container;
 import org.labkey.api.data.ContainerFilter;
 import org.labkey.api.data.ContainerManager;
@@ -235,7 +236,14 @@ public class HDRLQuerySchema extends SimpleUserSchema
             SimpleFilter baseFilter = settings.getBaseFilter();
             if (StringUtils.isNotBlank(requestId))
             {
-                baseFilter.addAllClauses(new SimpleFilter(FieldKey.fromParts("inboundRequestId"), Integer.valueOf(requestId)));
+                try
+                {
+                    baseFilter.addAllClauses(new SimpleFilter(FieldKey.fromParts("inboundRequestId"), Integer.valueOf(requestId)));
+                }
+                catch (NumberFormatException e)
+                {
+                    throw new ApiUsageException("Invalid request id");
+                }
             }
 
             QueryView queryView = new QueryView(this, settings, errors)


### PR DESCRIPTION
#### Rationale
Error discovered by crawler:
```
java.lang.NumberFormatException: For input string: "">'>'"<script>alert('8(')</script>"
	at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67)
	at java.base/java.lang.Integer.parseInt(Integer.java:654)
	at java.base/java.lang.Integer.valueOf(Integer.java:999)
	at org.labkey.hdrl.query.HDRLQuerySchema.createView(HDRLQuerySchema.java:238)
	at org.labkey.api.query.QueryForm.init(QueryForm.java:336)
	at org.labkey.api.query.QueryForm.getQueryView(QueryForm.java:81)
	at org.labkey.query.controllers.QueryController$ExecuteQueryAction.getView(QueryController.java:1641)
	at org.labkey.query.controllers.QueryController$ExecuteQueryAction.getView(QueryController.java:1629)
```

#### Related Pull Requests
* N/A

#### Changes
* Handle invalid request ID in HDRLQuerySchema
