### PR TITLE
Make select inactive modules unreachable

### DIFF
--- a/hdrl/src/org/labkey/hdrl/HDRLModule.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLModule.java
@@ -73,9 +73,9 @@ public class HDRLModule extends DefaultModule
     }
 
     @Override
-    public boolean isAvailableOnlyWhenActive()
+    public boolean isAvailable(Container container)
     {
-        return true;
+        return container.getActiveModules().contains(this);
     }
 
     @Override

--- a/hdrl/src/org/labkey/hdrl/HDRLModule.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLModule.java
@@ -73,6 +73,12 @@ public class HDRLModule extends DefaultModule
     }
 
     @Override
+    public boolean isAvailableOnlyWhenActive()
+    {
+        return true;
+    }
+
+    @Override
     public void doStartup(ModuleContext moduleContext)
     {
         // add a container listener so we'll know when our container is deleted:


### PR DESCRIPTION
#### Rationale
Many modules don't make sense to access in a container if they're not enabled and intended to be used. Mothership is a good example. We've long hidden their schemas, but they've still been accessible via their controllers and the More Modules admin menu.

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7355

#### Changes
* Hide HDRL module when not active
