### PR TITLE
Allow access to HDRL in root container

### DIFF
--- a/hdrl/src/org/labkey/hdrl/HDRLModule.java
+++ b/hdrl/src/org/labkey/hdrl/HDRLModule.java
@@ -75,7 +75,7 @@ public class HDRLModule extends DefaultModule
     @Override
     public boolean isAvailable(Container container)
     {
-        return container.getActiveModules().contains(this);
+        return container.isRoot() || container.getActiveModules().contains(this);
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
HDRL has an admin console link that needs to be available in the root container.

https://teamcity.labkey.org/buildConfiguration/LabkeyTrunk_GitPostgres/3821160?buildTab=tests&status=failed

#### Related Pull Requests
* https://github.com/LabKey/premiumModules/pull/451

#### Changes
* Allow access to HDRL in the root