### PR TITLE
Avoid NPE when bad queryKey is provided

### DIFF
--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBBaseController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBBaseController.java
@@ -157,87 +157,85 @@ public class PepDBBaseController extends SpringActionController
             this.labId = labId;
         }
 
-        public boolean validate(Errors errors) throws SQLException
+        public boolean validate(Errors errors)
         {
             if(getQueryKey() == null || StringUtils.trimToNull(getQueryKey()) == null)
                 errors.reject(null, "The Search Criteria must be entered.");
             String qValue = getQueryValue();
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_PARENT_SEQUENCE))
+            if (getQueryKey() != null)
             {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "The Parent Sequence must be entered.");
-            }
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_CHILD_SEQUENCE))
-            {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "The Child Sequence must be entered.");
-            }
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_GROUP_ID))
-            {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "Peptide Group must be selected to get peptides in a group.");
-                /*
-                if(StringUtils.trimToNull(getLabId()) == null)
-                    errors.reject(null, "Peptide Number must be entered.");
-                    */
-            }
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_POOL_ID))
-            {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "Peptide Pool Name must be selected to get peptides in a pool.");
-            }
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_PROTEIN_CAT_ID))
-            {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "Protein Category must be selected to get peptides in a protein category.");
-                else
+                switch (getQueryKey())
                 {
-                    ProteinCategory pc = PepDBManager.getProCatByID(Integer.parseInt(getQueryValue()));
-                    if(pc.getProtein_cat_desc().trim().contains("-"))
+                    case PepDBSchema.COLUMN_PARENT_SEQUENCE ->
                     {
-                        if(StringUtils.trimToNull(getAAStart()) != null || StringUtils.trimToNull(getAAEnd()) != null)
-                            errors.reject(null,"When you select a hyphanated Protein Category : "+pc.getProtein_cat_desc()+" AAStart & AAEnd values are not allowed.");
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "The Parent Sequence must be entered.");
                     }
-                    else
+                    case PepDBSchema.COLUMN_CHILD_SEQUENCE ->
                     {
-                        if(StringUtils.trimToNull(getAAStart()) != null && validateInteger(getAAStart().trim()) == null)
-                            errors.reject(null, "AAStart must be an Integer.");
-                        if(StringUtils.trimToNull(getAAEnd()) != null && validateInteger(getAAEnd().trim()) == null)
-                            errors.reject(null, "AAEnd must be an Integer.");
-                        if(StringUtils.trimToNull(getAAStart()) != null && validateInteger(getAAStart().trim()) != null
-                                && StringUtils.trimToNull(getAAEnd()) != null && validateInteger(getAAEnd().trim()) != null
-                                && validateInteger(getAAStart().trim()) > validateInteger(getAAEnd().trim()))
-                            errors.reject(null, "AAStart must be less than or equal to AAEnd.");
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "The Child Sequence must be entered.");
                     }
-                }
-            }
-            if (getQueryKey() != null && getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_ID))
-            {
-                if (StringUtils.trimToNull(qValue) == null)
-                    errors.reject(null, "The Peptide Id range must be entered.");
-                if (qValue != null && !qValue.isEmpty())
-                {
-                    if (!(qValue.matches("\\d+-\\d+")))
+                    case PepDBSchema.COLUMN_PEPTIDE_GROUP_ID ->
                     {
-                        errors.reject(null, "To get the peptides in the range you should specify the Range of numbers.\n" +
-                                "The format for specify the range of peptide is <number>-<number> Example would be 30-100");
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "Peptide Group must be selected to get peptides in a group.");
                     }
-                    else
+                    case PepDBSchema.COLUMN_PEPTIDE_POOL_ID ->
                     {
-                        String[] range = qValue.split("-");
-                        if (Integer.parseInt(range[0]) > Integer.parseInt(range[1]))
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "Peptide Pool Name must be selected to get peptides in a pool.");
+                    }
+                    case PepDBSchema.COLUMN_PROTEIN_CAT_ID ->
+                    {
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "Protein Category must be selected to get peptides in a protein category.");
+                        else
                         {
-                            errors.reject(null, "The minimum value which is before '-' should be less than the max value which is after '-'.\n");
-
+                            ProteinCategory pc = PepDBManager.getProCatByID(Integer.parseInt(getQueryValue()));
+                            if (pc.getProtein_cat_desc().trim().contains("-"))
+                            {
+                                if (StringUtils.trimToNull(getAAStart()) != null || StringUtils.trimToNull(getAAEnd()) != null)
+                                    errors.reject(null, "When you select a hyphanated Protein Category : " + pc.getProtein_cat_desc() + " AAStart & AAEnd values are not allowed.");
+                            }
+                            else
+                            {
+                                if (StringUtils.trimToNull(getAAStart()) != null && validateInteger(getAAStart().trim()) == null)
+                                    errors.reject(null, "AAStart must be an Integer.");
+                                if (StringUtils.trimToNull(getAAEnd()) != null && validateInteger(getAAEnd().trim()) == null)
+                                    errors.reject(null, "AAEnd must be an Integer.");
+                                if (StringUtils.trimToNull(getAAStart()) != null && validateInteger(getAAStart().trim()) != null
+                                        && StringUtils.trimToNull(getAAEnd()) != null && validateInteger(getAAEnd().trim()) != null
+                                        && validateInteger(getAAStart().trim()) > validateInteger(getAAEnd().trim()))
+                                    errors.reject(null, "AAStart must be less than or equal to AAEnd.");
+                            }
+                        }
+                    }
+                    case PepDBSchema.COLUMN_PEPTIDE_ID ->
+                    {
+                        if (StringUtils.trimToNull(qValue) == null)
+                            errors.reject(null, "The Peptide Id range must be entered.");
+                        if (qValue != null && !qValue.isEmpty())
+                        {
+                            if (!(qValue.matches("\\d+-\\d+")))
+                            {
+                                errors.reject(null, "To get the peptides in the range you should specify the Range of numbers.\n" +
+                                        "The format for specify the range of peptide is <number>-<number> Example would be 30-100");
+                            }
+                            else
+                            {
+                                String[] range = qValue.split("-");
+                                if (Integer.parseInt(range[0]) > Integer.parseInt(range[1]))
+                                {
+                                    errors.reject(null, "The minimum value which is before '-' should be less than the max value which is after '-'.\n");
+                                }
+                            }
                         }
                     }
                 }
             }
-            if(errors != null && errors.getErrorCount() >0)
-                return false;
-            return true;
+            return errors == null || !errors.hasErrors();
         }
-
     }
 
     public static class DisplayPeptideForm

--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
@@ -32,7 +32,6 @@ import org.labkey.api.security.permissions.UpdatePermission;
 import org.labkey.api.view.ActionURL;
 import org.labkey.api.view.DetailsView;
 import org.labkey.api.view.GridView;
-import org.labkey.api.view.HttpView;
 import org.labkey.api.view.InsertView;
 import org.labkey.api.view.JspView;
 import org.labkey.api.view.NavTree;
@@ -170,29 +169,29 @@ public class PepDBController extends PepDBBaseController
         @Override
         public ModelAndView getView(PeptideQueryForm form, BindException errors) throws Exception
         {
-            if (!form.validate(errors))
+            if (form.validate(errors))
             {
-                return new JspView<>(PAGE_PEPTIDE_GROUP_SELECT, form, errors);
+                PropertyValues pv = this.getPropertyValues();
+                GridView gridView = switch (form.getQueryKey())
+                {
+                    case PepDBSchema.COLUMN_PEPTIDE_GROUP_ID -> getGridViewByGroup(form, pv);
+                    case PepDBSchema.COLUMN_PEPTIDE_POOL_ID -> getGridViewByPool(form, pv);
+                    case PepDBSchema.COLUMN_PROTEIN_CAT_ID -> getGridViewByProtein(form, pv);
+                    case PepDBSchema.COLUMN_PEPTIDE_SEQUENCE -> getGridViewBySequence(form, pv);
+                    case PepDBSchema.COLUMN_PARENT_SEQUENCE -> getGridViewByParent(form, pv);
+                    case PepDBSchema.COLUMN_CHILD_SEQUENCE -> getGridViewByChild(form, pv);
+                    default -> null;
+                };
+                if (gridView != null)
+                {
+                    ViewContext ctx = getViewContext();
+                    HttpSession session = ctx.getRequest().getSession(true);
+                    session.setAttribute("QUERY_FORM", form);
+                    return gridView;
+                }
+                errors.reject(null, "Unrecognized queryKey: " + form.getQueryKey());
             }
-            PropertyValues pv = this.getPropertyValues();
-            ViewContext ctx = getViewContext();
-            HttpSession session = ctx.getRequest().getSession(true);
-            session.setAttribute("QUERY_FORM", form);
-            GridView gridView = switch (form.getQueryKey())
-            {
-                case PepDBSchema.COLUMN_PEPTIDE_GROUP_ID -> getGridViewByGroup(form, pv);
-                case PepDBSchema.COLUMN_PEPTIDE_POOL_ID -> getGridViewByPool(form, pv);
-                case PepDBSchema.COLUMN_PROTEIN_CAT_ID -> getGridViewByProtein(form, pv);
-                case PepDBSchema.COLUMN_PEPTIDE_SEQUENCE -> getGridViewBySequence(form, pv);
-                case PepDBSchema.COLUMN_PARENT_SEQUENCE -> getGridViewByParent(form, pv);
-                case PepDBSchema.COLUMN_CHILD_SEQUENCE -> getGridViewByChild(form, pv);
-                default -> null;
-            };
-            if (gridView == null)
-            {
-                HttpView.redirect(new ActionURL(SearchForPeptidesAction.class, getContainer()));
-            }
-            return gridView;
+            return new JspView<>(PAGE_PEPTIDE_GROUP_SELECT, form, errors);
         }
 
         @Override

--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
@@ -178,31 +178,16 @@ public class PepDBController extends PepDBBaseController
             ViewContext ctx = getViewContext();
             HttpSession session = ctx.getRequest().getSession(true);
             session.setAttribute("QUERY_FORM", form);
-            GridView gridView = new GridView(new DataRegion(), (BindException) null);
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_GROUP_ID))
+            GridView gridView = switch (form.getQueryKey())
             {
-                gridView = getGridViewByGroup(form, pv);
-            }
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_POOL_ID))
-            {
-                gridView = getGridViewByPool(form, pv);
-            }
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_PROTEIN_CAT_ID))
-            {
-                gridView = getGridViewByProtein(form, pv);
-            }
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_PEPTIDE_SEQUENCE))
-            {
-                gridView = getGridViewBySequence(form, pv);
-            }
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_PARENT_SEQUENCE))
-            {
-                gridView = getGridViewByParent(form, pv);
-            }
-            if (form.getQueryKey().equals(PepDBSchema.COLUMN_CHILD_SEQUENCE))
-            {
-                gridView = getGridViewByChild(form, pv);
-            }
+                case PepDBSchema.COLUMN_PEPTIDE_GROUP_ID -> getGridViewByGroup(form, pv);
+                case PepDBSchema.COLUMN_PEPTIDE_POOL_ID -> getGridViewByPool(form, pv);
+                case PepDBSchema.COLUMN_PROTEIN_CAT_ID -> getGridViewByProtein(form, pv);
+                case PepDBSchema.COLUMN_PEPTIDE_SEQUENCE -> getGridViewBySequence(form, pv);
+                case PepDBSchema.COLUMN_PARENT_SEQUENCE -> getGridViewByParent(form, pv);
+                case PepDBSchema.COLUMN_CHILD_SEQUENCE -> getGridViewByChild(form, pv);
+                default -> null;
+            };
             if (gridView == null)
             {
                 HttpView.redirect(new ActionURL(SearchForPeptidesAction.class, getContainer()));


### PR DESCRIPTION
#### Rationale
The crawler induced an NPE in `pepdb-getPeptides.view` by supplying a bogus `queryKey` parameter value

#### Changes
* Convert a couple chains of `if` statements into `switch` (thanks, Claude)
* Show the search form and an error message if queryKey is unrecognized. This matches the queryKey missing case.
