### PR TITLE
Drop redundant index

### DIFF
--- a/ms2extensions/resources/schemas/dbscripts/postgresql/ms2extensions-26.000-26.001.sql
+++ b/ms2extensions/resources/schemas/dbscripts/postgresql/ms2extensions-26.000-26.001.sql
@@ -1,0 +1,2 @@
+-- idx_ms2runaggregates_ms2run [ms2Run] overlaps with pk_ms2runaggregates [ms2Run]
+DROP INDEX ms2extensions.idx_ms2runaggregates_ms2run;

--- a/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
+++ b/ms2extensions/src/org/labkey/ms2extensions/MS2ExtensionsModule.java
@@ -64,7 +64,7 @@ public class MS2ExtensionsModule extends DefaultModule
     @Override
     public @Nullable Double getSchemaVersion()
     {
-        return 26.000;
+        return 26.001;
     }
 
     @Override


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630