### PR TITLE
Drop redundant indices

### DIFF
--- a/peptideInventory/module.properties
+++ b/peptideInventory/module.properties
@@ -1,3 +1,3 @@
 Name: PeptideInventory
-SchemaVersion: 26.000
+SchemaVersion: 26.001
 ManageVersion: true

--- a/peptideInventory/resources/schemas/dbscripts/postgresql/peptideinventory-26.000-26.001.sql
+++ b/peptideInventory/resources/schemas/dbscripts/postgresql/peptideinventory-26.000-26.001.sql
@@ -1,0 +1,6 @@
+-- Converting uq_lotassignment [peptideId, container, lotNumber] from unique to non-unique index because pk_lotassignment [peptideId, container] overlaps it with a smaller column set
+ALTER TABLE peptideinventory.lotAssignment DROP CONSTRAINT uq_lotassignment;
+CREATE INDEX ix_lotassignment ON peptideinventory.lotAssignment(peptideId, container, lotNumber);
+-- Converting uq_rcpoolassignment [peptideId, container, rcPoolId] from unique to non-unique index because pk_rcpoolassignment [peptideId, container] overlaps it with a smaller column set
+ALTER TABLE peptideinventory.rcPoolAssignment DROP CONSTRAINT uq_rcpoolassignment;
+CREATE INDEX ix_rcpoolassignment ON peptideinventory.rcPoolAssignment(peptideId, container, rcPoolId);


### PR DESCRIPTION
#### Rationale
Redundant indices waste disk space and degrade insert/update/delete performance

#### Related Pull Requests
* https://github.com/LabKey/platform/pull/7630