### PR TITLE
DisplayPeptideGroupInformationAction revert containerId check from previous PR

### DIFF
--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBController.java
@@ -443,7 +443,7 @@ public class PepDBController extends PepDBBaseController
                 pg = PepDBManager.getPeptideGroupByID(peptideGroupId);
             }
             catch (NumberFormatException ignored) {}
-            if (pg == null || !getContainer().getId().equalsIgnoreCase(pg.getContainerId()))
+            if (pg == null)
             {
                 throw new NotFoundException();
             }

--- a/pepdb/src/org/scharp/atlas/pepdb/PepDBManager.java
+++ b/pepdb/src/org/scharp/atlas/pepdb/PepDBManager.java
@@ -295,10 +295,12 @@ public class PepDBManager
 
     public static Peptides[] getHyphanatedParents(Peptides p) throws SQLException
     {
-        String sql = "select * from "+schema.getTableInfoPeptides()+" where peptides.protein_cat_id = ? " +
-                " and peptides.peptide_sequence LIKE '%"+p.getPeptide_sequence()+"%' " +
-                " and child = false";
-        Peptides[] peptides = new SqlSelector(schema.getSchema(), sql, new Object[]{p.getProtein_cat_id()}).getArray(Peptides.class);
+        // GitHub Kanban #1929: parameterize the LIKE clause for the stored peptide_sequence
+        SQLFragment sql = new SQLFragment("select * from "+schema.getTableInfoPeptides()+" where peptides.protein_cat_id = ? ", p.getProtein_cat_id());
+        sql.append(" and peptides.peptide_sequence LIKE ? ");
+        sql.add("%" + schema.getSchema().getSqlDialect().encodeLikeOpSearchString(p.getPeptide_sequence()) + "%");
+        sql.append(" and child = false");
+        Peptides[] peptides = new SqlSelector(schema.getSchema(), sql).getArray(Peptides.class);
         return peptides;
     }
 

--- a/pepdb/test/src/org/labkey/test/tests/pepdb/PepDBModuleTest.java
+++ b/pepdb/test/src/org/labkey/test/tests/pepdb/PepDBModuleTest.java
@@ -31,6 +31,7 @@ import org.labkey.test.TestFileUtils;
 import org.labkey.test.TestTimeoutException;
 import org.labkey.test.WebTestHelper;
 import org.labkey.test.categories.CustomModules;
+import org.labkey.test.util.DataRegionTable;
 import org.labkey.test.util.LogMethod;
 import org.labkey.test.util.PostgresOnlyTest;
 
@@ -180,6 +181,15 @@ public class PepDBModuleTest extends BaseWebDriverTest implements PostgresOnlyTe
 
         clickAndWait(Locator.css("a.labkey-button > span"));
 
+        // Verify peptide group detail page
+        clickAndWait(Locator.linkWithText("List Peptide Groups"));
+        clickAndWait(Locator.linkWithText("gagptegprac"));
+        assertTextPresentInThisOrder(
+                "Group Information from peptide_group table for group : gagptegprac",
+                "There are (16) peptides in the 'gagptegprac' peptide group."
+        );
+        DataRegionTable pepTable = new DataRegionTable("group_peptides", getDriver());
+        assertEquals("Peptide table for group does not have expected number of rows", 16, pepTable.getDataRowCount());
 
         /*
          *


### PR DESCRIPTION
#### Rationale
Related PR made an update for a crawler issue but added an extra containerId check that doesn't apply in this case. Also convert one pepdb manager method to use SQLFragment.

#### Related Pull Requests
* https://github.com/LabKey/customModules/pull/212

